### PR TITLE
New utils module providing cached_property.

### DIFF
--- a/askomics/ask_view.py
+++ b/askomics/ask_view.py
@@ -117,7 +117,7 @@ class AskView(object):
         for src_file in source_files:
             infos = {}
             infos['name'] = src_file.name
-            infos['headers'] = src_file.get_headers()
+            infos['headers'] = src_file.headers
             infos['preview_data'] = src_file.get_preview_data()
             infos['column_types'] = src_file.guess_column_types(infos['preview_data'])
 

--- a/askomics/libaskomics/source_file/SourceFile.py
+++ b/askomics/libaskomics/source_file/SourceFile.py
@@ -9,7 +9,7 @@ from itertools import count
 import os.path
 
 
-from askomics.libaskomics.utils import cached_property, HaveCachedProperties, pformatGenericObject
+from askomics.libaskomics.utils import cached_property, HaveCachedProperties, pformat_generic_object
 
 class SourceFileSyntaxError(SyntaxError):
     pass
@@ -54,7 +54,7 @@ class SourceFile(HaveCachedProperties):
         """
         with open(self.path, 'r') as tabfile:
             dialect = csv.Sniffer().sniff(tabfile.read(self.preview_limit))
-            self.log.debug("CSV dialect in %r: %s" % (self.path, pformatGenericObject(dialect)))
+            self.log.debug("CSV dialect in %r: %s" % (self.path, pformat_generic_object(dialect)))
             return dialect
 
     @cached_property

--- a/askomics/libaskomics/source_file/SourceFile.py
+++ b/askomics/libaskomics/source_file/SourceFile.py
@@ -9,7 +9,7 @@ from itertools import count
 import os.path
 
 
-from ..utils import cached_property, HaveCachedProperties, pformatGenericObject
+from askomics.libaskomics.utils import cached_property, HaveCachedProperties, pformatGenericObject
 
 class SourceFileSyntaxError(SyntaxError):
     pass
@@ -228,6 +228,9 @@ class SourceFile(HaveCachedProperties):
 
     @cached_property
     def category_values(self):
+        """
+        A (lazily cached) dictionary mapping from column name (header) to the set of unique values.
+        """
         self.log.warning("category_values are computed independently, get_turtle should be used to generate both at once")
         category_values = defaultdict(set) # key=name of a column of 'category' type -> list of found values
 

--- a/askomics/libaskomics/utils.py
+++ b/askomics/libaskomics/utils.py
@@ -1,0 +1,82 @@
+"""Some python magic to provide utility Bases, decorators, utility functions, etc. """
+
+from pprint import pformat
+
+__all__ = ['pformatGenericObject',
+           'cached_property', 'HaveCachedProperties']
+
+
+def pformatGenericObject(obj):
+    "Pretty print a object and its attributes to string"
+    pubattrs = {k:v for k, v in obj.__dict__.items() if not k.startswith('_') }
+    name = getattr(obj, '__qualname__', type(obj).__qualname__)
+    return "{0}({1})".format(name, pformat(pubattrs))
+
+class cached_property(object):
+    """Like @property on a member function, but cache the calculation in
+    self.__dict__[function name].
+    The function is called only once since the cache stored as an instance
+    attribute override the property residing in the class attributes. Following accesses
+    cost no more than standard Python attribute access.
+    If the instance attribute is deleted the next access will re-evaluate the function.
+    Source: https://blog.ionelmc.ro/2014/11/04/an-interesting-python-descriptor-quirk/
+    usage:
+        class Shape(object):
+
+            @cached_property
+            def area(self):
+                # compute value
+                return value
+    """
+    __slots__ = ('func')
+    def __init__(self, func):
+        self.func = func
+
+    def __get__(self, obj, cls):
+        value = obj.__dict__[self.func.__name__] = self.func(obj)
+        return value
+
+
+class HaveCachedProperties(object):
+    """Provide cache management for classes using cached_property."""
+    @classmethod
+    def getCachedProperties(cls):
+        # cached_property instances are in the class dict with other class attributes
+        return (attr for attr, cp in cls.__dict__.items()
+                if isinstance(cp, cached_property))
+
+    def get_cache(self):
+        """Explicit access (as a dictionary) to all the values cached in the attributes of this object.
+        Return the subset of self.__dict__ for keys in self.getCachedProperties().
+        """
+        properties = set(self.getCachedProperties())
+        # The caches are stored in the instance dictionary with the same names than the properties
+        return {attr: cache for attr, cache in self.__dict__.items() if attr in properties}
+
+    def set_cache(self, cache_dict, reset=True):
+        """ Set the cache.
+        If reset is True, reset caches not present in cache_dict keys().
+        With reset = False, a reset is still possible if cache_dict[key] is None
+
+            self.cache = cache_dict
+        is equivalent to:
+            self.set_cache(cache_dict, reset=True)
+        """
+        properties = set(self.getCachedProperties())
+        if not reset:
+            properties &= cache_dict.keys()
+
+        for key in properties:
+            cache = cache_dict.get(key)
+            if cache is None:
+                self.__dict__.pop(key, None)
+            else:
+                self.__dict__[key] = cache
+
+    def reset_cache(self):
+        "Equivalent to self.set_cache({}, reset=True) or del self.cache"
+        for key in self.getCachedProperties():
+            self.__dict__.pop(key, None)
+
+    cache = property(get_cache, set_cache, reset_cache,
+                     "Explicit access (as a dictionary) to all the values cached in the attributes of this object.")

--- a/askomics/libaskomics/utils.py
+++ b/askomics/libaskomics/utils.py
@@ -1,5 +1,6 @@
 """Some python magic to provide utility Bases, decorators, utility functions, etc. """
 
+import sys
 from pprint import pformat
 
 __all__ = ['pformatGenericObject',
@@ -9,7 +10,11 @@ __all__ = ['pformatGenericObject',
 def pformatGenericObject(obj):
     "Pretty print a object and its attributes to string"
     pubattrs = {k:v for k, v in obj.__dict__.items() if not k.startswith('_') }
-    name = getattr(obj, '__qualname__', type(obj).__qualname__)
+
+    if sys.version_info >= (3,3):
+        name = getattr(obj, '__qualname__', type(obj).__qualname__)
+    else:
+        name = getattr(obj, '__name__', type(obj).__name__)
     return "{0}({1})".format(name, pformat(pubattrs))
 
 class cached_property(object):

--- a/askomics/libaskomics/utils.py
+++ b/askomics/libaskomics/utils.py
@@ -52,9 +52,9 @@ class HaveCachedProperties(object):
 
     def get_cache(self):
         """Explicit access (as a dictionary) to all the values cached in the attributes of this object.
-        Return the subset of self.__dict__ for keys in self.getCachedProperties().
+        Return the subset of self.__dict__ for keys in self.get_cached_properties().
         """
-        properties = set(self.getCachedProperties())
+        properties = set(self.get_cached_properties())
         # The caches are stored in the instance dictionary with the same names than the properties
         return {attr: cache for attr, cache in self.__dict__.items() if attr in properties}
 
@@ -67,7 +67,7 @@ class HaveCachedProperties(object):
         is equivalent to:
             self.set_cache(cache_dict, reset=True)
         """
-        properties = set(self.getCachedProperties())
+        properties = set(self.get_cached_properties())
         if not reset:
             properties &= cache_dict.keys()
 
@@ -80,7 +80,7 @@ class HaveCachedProperties(object):
 
     def reset_cache(self):
         "Equivalent to self.set_cache({}, reset=True) or del self.cache"
-        for key in self.getCachedProperties():
+        for key in self.get_cached_properties():
             self.__dict__.pop(key, None)
 
     cache = property(get_cache, set_cache, reset_cache,

--- a/askomics/libaskomics/utils.py
+++ b/askomics/libaskomics/utils.py
@@ -3,11 +3,11 @@
 import sys
 from pprint import pformat
 
-__all__ = ['pformatGenericObject',
+__all__ = ['pformat_generic_object',
            'cached_property', 'HaveCachedProperties']
 
 
-def pformatGenericObject(obj):
+def pformat_generic_object(obj):
     "Pretty print a object and its attributes to string"
     pubattrs = {k:v for k, v in obj.__dict__.items() if not k.startswith('_') }
 
@@ -45,7 +45,7 @@ class cached_property(object):
 class HaveCachedProperties(object):
     """Provide cache management for classes using cached_property."""
     @classmethod
-    def getCachedProperties(cls):
+    def get_cached_properties(cls):
         # cached_property instances are in the class dict with other class attributes
         return (attr for attr, cp in cls.__dict__.items()
                 if isinstance(cp, cached_property))

--- a/askomics/test/source_file_test.py
+++ b/askomics/test/source_file_test.py
@@ -2,7 +2,7 @@ import os
 import unittest
 import json
 import tempfile, shutil
-
+print('found')
 from askomics.libaskomics.source_file.SourceFile import SourceFile
 
 SIMPLE_SOURCE_FILE = os.path.join( os.path.dirname( __file__ ), "..", "test-data", "sourcefile.tsv.simple" )
@@ -18,7 +18,7 @@ class SourceFileTests(unittest.TestCase):
 
     def test_load_headers_from_file(self):
 
-        assert self.srcfile.get_headers() == ['head1', 'head2', 'head3']
+        assert self.srcfile.headers == ['head1', 'head2', 'head3']
 
     def test_load_preview_from_file(self):
 

--- a/askomics/test/source_file_test.py
+++ b/askomics/test/source_file_test.py
@@ -2,7 +2,7 @@ import os
 import unittest
 import json
 import tempfile, shutil
-print('found')
+
 from askomics.libaskomics.source_file.SourceFile import SourceFile
 
 SIMPLE_SOURCE_FILE = os.path.join( os.path.dirname( __file__ ), "..", "test-data", "sourcefile.tsv.simple" )

--- a/askomics/test/utils_test.py
+++ b/askomics/test/utils_test.py
@@ -1,0 +1,39 @@
+import unittest
+from askomics.libaskomics.utils import *
+
+class UtilsTest(unittest.TestCase):
+
+    @staticmethod
+    def test_property():
+        class TestProperty(HaveCachedProperties):
+            @cached_property
+            def test_property(self):
+                return "Ok1"
+
+            def set_cache(self, v):
+                "Test if the cached property can be set directly as an attribute."
+                self.test_property = v
+
+        t = TestProperty()
+        assert t.cache == {}, "starting with clear cache"
+
+        t.test_property # Compute the value and cache it
+        assert t.cache == {'test_property': 'Ok1'}, "cache computed on attribute access"
+
+        t.cache = {}
+        assert t.cache == {}, "Cache cleared on t.cache = {}"
+
+        t.set_cache("Ok2")
+        assert t.cache == {'test_property': 'Ok2'}, "Cache value set directly on the attribute"
+
+        del t.test_property
+        assert t.cache == {}, "deleting attribute delete the cache"
+
+        t.test_property # Compute the value and cache it
+        del t.cache
+        assert t.cache == {}, "deleting cache attribute delete the cache"
+
+        t.test_property # Compute the value and cache it
+        t.cache = { 'test_property': None }
+        assert t.cache == {}, "setting the cache dict with a None value delete the cache"
+


### PR DESCRIPTION
More transparent cache on python classes. 


### cached_property(member function)

Like @property on a member function, but cache the calculation in `self.__dict__[function name]`.
The function is called only once since the cache stored as an instance attribute override the property residing in the class attributes. Following accesses cost no more than standard Python attribute access.
If the instance attribute is deleted the next access will re-evaluate the function.
Source: https://blog.ionelmc.ro/2014/11/04/an-interesting-python-descriptor-quirk/
usage:
```python
class Shape(object):

    @cached_property
    def area(self):
        # compute value
        return value
```

## HaveCachedProperties
Used as a base class it provides cache management for classes using cached_property.
It's not mandatory for using cached_property, but it facilitate the access of  all cached attributes uder the `.cache` property

```python
class TestProperty(HaveCachedProperties):
    @cached_property
    def test_property(self):
        return "Ok"

t = TestProperty()
assert t.cache == {}

t.test_property # compute the poperty and cache it
assert t.cache == {'test_property': 'Ok'}

t.reset_cache() # equivalent del t.cache, t.cache  = {}
```
