### PR TITLE
Fuseki load

### DIFF
--- a/askomics/libaskomics/rdfdb/QueryLauncher.py
+++ b/askomics/libaskomics/rdfdb/QueryLauncher.py
@@ -139,13 +139,15 @@ class QueryLauncher(ParamManager):
 
         return res
 
-    def fuseki_load_data(self, filename):
+    def upload_data(self, filename):
         """
         Load a ttl file into the triple store using requests module and Fuseki
         upload method which allows upload of big data into Fuseki (instead of LOAD method).
 
         :param filename: name of the file, fp.name from Source.py
         :return: response of the request and queryTime
+
+        Not working for Virtuoso because there is no upload files url.
         """
         self.log.debug("Loading into triple store (HTTP method) the content of: %s", filename)
 
@@ -163,7 +165,7 @@ class QueryLauncher(ParamManager):
         queryTime = time1 - time0
 
         if self.log.isEnabledFor(logging.DEBUG):
-            self.log.debug("------- FUSEKI LOAD DONE --------- (t=%.3fs)\n%s", queryTime,  pformat(response))
+            self.log.debug("------- UPLOAD DONE --------- (t=%.3fs)\n%s", queryTime,  pformat(response))
 
         return response
 

--- a/askomics/libaskomics/source_file/SourceFile.py
+++ b/askomics/libaskomics/source_file/SourceFile.py
@@ -533,7 +533,7 @@ class SourceFile(ParamManager, HaveCachedProperties):
         url = urlbase+"/ttl/"+os.path.basename(fp.name)
         data = {}
         try:
-            if self.is_defined("askomics.file_upload_url") and "8890" not in self.get_param('askomics.file_upload_url'):
+            if self.is_defined("askomics.file_upload_url"):
                 res = ql.upload_data(fp.name)
             else:
                 res = ql.load_data(url)

--- a/askomics/libaskomics/source_file/SourceFile.py
+++ b/askomics/libaskomics/source_file/SourceFile.py
@@ -520,6 +520,7 @@ class SourceFile(ParamManager, HaveCachedProperties):
     def load_data_from_file(self, fp, urlbase):
         """
         Load a locally created ttl file in the triplestore using http (with load_data(url)) or with the filename for Fuseki (with fuseki_load_data(fp.name)).
+
         :param fp: a file handle for the file to load
         :param urlbase:the base URL of current askomics instance. It is used to let triple stores access some askomics temporary ttl files using http.
         :return: a dictionnary with information on the success or failure of the operation
@@ -532,7 +533,10 @@ class SourceFile(ParamManager, HaveCachedProperties):
         url = urlbase+"/ttl/"+os.path.basename(fp.name)
         data = {}
         try:
-            res = ql.load_data(url)
+            if self.is_defined("askomics.file_upload_url"):
+                res, queryTime = ql.fuseki_load_data(fp.name)
+            else:
+                res = ql.load_data(url)
             data['status'] = 'ok'
         except Exception as e:
             self._format_exception(e, data=data)

--- a/askomics/libaskomics/source_file/SourceFile.py
+++ b/askomics/libaskomics/source_file/SourceFile.py
@@ -533,8 +533,8 @@ class SourceFile(ParamManager, HaveCachedProperties):
         url = urlbase+"/ttl/"+os.path.basename(fp.name)
         data = {}
         try:
-            if self.is_defined("askomics.file_upload_url"):
-                res = ql.fuseki_load_data(fp.name)
+            if self.is_defined("askomics.file_upload_url") and "8890" not in self.get_param('askomics.file_upload_url'):
+                res = ql.upload_data(fp.name)
             else:
                 res = ql.load_data(url)
             data['status'] = 'ok'

--- a/askomics/libaskomics/source_file/SourceFile.py
+++ b/askomics/libaskomics/source_file/SourceFile.py
@@ -534,7 +534,7 @@ class SourceFile(ParamManager, HaveCachedProperties):
         data = {}
         try:
             if self.is_defined("askomics.file_upload_url"):
-                res, queryTime = ql.fuseki_load_data(fp.name)
+                res = ql.fuseki_load_data(fp.name)
             else:
                 res = ql.load_data(url)
             data['status'] = 'ok'

--- a/configs/development.fuseki.ini
+++ b/configs/development.fuseki.ini
@@ -5,6 +5,8 @@
 
 [app:main]
 askomics.updatepoint = http://localhost:3030/database/update
+# askomics.file_upload_url isn't a standard protocol and is only tested with Fuseki
+askomics.file_upload_url = http://localhost:3030/database/upload
 askomics.max_content_size_to_update_database=100000
 askomics.endpoint = http://localhost:3030/database/query
 askomics.hack_virtuoso=false

--- a/configs/development.ini
+++ b/configs/development.ini
@@ -51,7 +51,6 @@ askomics.graph=urn:sparql:tests-askomics:insert:informative1
 askomics.endpoint = http://localhost:8890/sparql
 askomics.max_content_size_to_update_database=500000
 askomics.hack_virtuoso=true
-askomics.file_upload_url = http://localhost:8890/conductor/rdf_import.vspx
 askomics.debug = true
 
 #

--- a/configs/development.ini
+++ b/configs/development.ini
@@ -37,9 +37,10 @@ askomics.graph=urn:sparql:tests-askomics:insert:informative1
 # --------------
 askomics.endpoint = http://localhost:3030/database/query
 askomics.updatepoint = http://localhost:3030/database/update
-askomics.max_content_size_to_update_database=100000
-askomics.hack_virtuoso=False
-askomics.debug=true
+askomics.file_upload_url = http://localhost:3030/database/upload
+askomics.max_content_size_to_update_database = 100000
+askomics.hack_virtuoso = False
+askomics.debug = true
 
 #
 # Exec service :

--- a/configs/development.ini
+++ b/configs/development.ini
@@ -35,12 +35,12 @@ askomics.graph=urn:sparql:tests-askomics:insert:informative1
 #
 # FUSEKI DATABASE (askomics/fuseki see in this directory docker/fuseki)
 # --------------
-askomics.endpoint = http://localhost:3030/database/query
-askomics.updatepoint = http://localhost:3030/database/update
-askomics.file_upload_url = http://localhost:3030/database/upload
-askomics.max_content_size_to_update_database = 100000
-askomics.hack_virtuoso = False
-askomics.debug = true
+#askomics.endpoint = http://localhost:3030/database/query
+#askomics.updatepoint = http://localhost:3030/database/update
+#askomics.file_upload_url = http://localhost:3030/database/upload
+#askomics.max_content_size_to_update_database = 100000
+#askomics.hack_virtuoso = False
+#askomics.debug = true
 
 #
 # Exec service :
@@ -48,9 +48,11 @@ askomics.debug = true
 #
 #VIRTUOSO DATABASE
 #-----------------
-#askomics.endpoint = http://localhost:8890/sparql
-#askomics.max_content_size_to_update_database=500000
-#askomics.hack_virtuoso=true
+askomics.endpoint = http://localhost:8890/sparql
+askomics.max_content_size_to_update_database=500000
+askomics.hack_virtuoso=true
+askomics.file_upload_url = http://localhost:8890/conductor/rdf_import.vspx
+askomics.debug = true
 
 #
 # Exec service :

--- a/configs/production.fuseki.ini
+++ b/configs/production.fuseki.ini
@@ -5,6 +5,8 @@
 
 [app:main]
 askomics.updatepoint = http://localhost:3030/database/update
+# askomics.file_upload_url isn't a standard protocol and is only tested with Fuseki
+askomics.file_upload_url = http://localhost:3030/database/upload
 askomics.max_content_size_to_update_database=10000
 askomics.endpoint = http://localhost:3030/database/query
 askomics.hack_virtuoso = false

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ requires = [
     'pyramid-debugtoolbar==3.0.1',
     'waitress==0.9.0',
     'SPARQLWrapper==1.7.6',
+    'requests==2.10.0',
     ]
 
 setup(name='Askomics',


### PR DESCRIPTION
Add a function which improves data load with Fuseki by using Fuseki upload files method. 
Although this function is actually wrote for Fuseki, it could be generalized if we need to load big files in other triplet-store that have upload files method.

This requires the use of a HTTP request module (SPARQLWrapper can't do that because it doesn't send a SPARQL query). So we use a module named 'requests'. It is very easy to use and fast. Parameters are automatically encoded which in this case is useful. 

This module isn't present in default Python library so it's added to 'requirement.txt'. The two sh script (launchAskomics.sh and launchAskomics-dev.sh) are modified to read and install modules present in 'requirement.txt'.

To see HTTP Error, a class SPARQLError is added.

Also query time for each query is measured and wrote in the log by using module 'time'.