### PR TITLE
Fix download incomplete query and bad behaviour after category selection

### DIFF
--- a/askomics/ask_view.py
+++ b/askomics/ask_view.py
@@ -349,17 +349,10 @@ class AskView(object):
 
         export = bool(int(body['export']))
         sqb = SparqlQueryBuilder(self.settings, self.request.session)
-        return_only_query = bool(int(body['return_only_query']))
+        query = sqb.load_from_query_json(body).query
 
-        if body['uploaded'] != '':
-            if export:
-                query = body['uploaded'].replace('LIMIT 30', 'LIMIT 10000')
-            else:
-                query = body['uploaded']
-        else:
-            query = sqb.load_from_query_json(body).query
-
-        if return_only_query:
+        assert type(body['return_only_query']) is bool
+        if body['return_only_query']:
             data['query'] = query
             return data
 

--- a/askomics/static/css/style.css
+++ b/askomics/static/css/style.css
@@ -46,7 +46,7 @@ pre {
 
 .display {
     float: right;
-    right: 3%;
+    padding-right: 1%;
     font-size: 16px;
     padding-top: 5px;
 }

--- a/askomics/static/js/askomics.js
+++ b/askomics/static/js/askomics.js
@@ -18,9 +18,6 @@ function startVisualisation() {
     graph = new myGraph("#svgdiv");
     graph.addNode(startPoint);
     addDisplay(startPoint.id);
-
-    // Save initial query in the download button
-    launchQuery(0, 0, true);
 }
 
 function loadStartPoints() {
@@ -160,6 +157,21 @@ function hideModal(){
 }
 
 
+function downloadTextAsFile(filename, text) {
+    // Download text as file
+  var element = document.createElement('a');
+  element.setAttribute('href', 'data:text/plain;charset=utf-8,' + encodeURIComponent(text));
+  element.setAttribute('download', filename);
+
+  element.style.display = 'none';
+  document.body.appendChild(element);
+
+  element.click();
+
+  document.body.removeChild(element);
+}
+
+
 $(function () {
     //Following code is automatically executed at start or is triggered by the action of the user
 
@@ -178,17 +190,19 @@ $(function () {
                 $("#nodeDetails").hide();
                 $("#queryBuilder").show();
                 $("#graph").attr("class", "col-md-12");
-                $("#uploadedQuery").show();
-                $("#uploadedQuery").text(contents);
-                $("a#btn-qdown").attr("href", "data:text/plain;charset=UTF-8," + encodeURIComponent(contents));
+                $("#uploadedQuery").text(contents).show();
             };
             fr.readAsText(uploadedFile);
         }
     });
 
-    // Update of the query to download if an uploaded query is edited in AskOmics
-    $("#uploadedQuery").bind("DOMSubtreeModified", function() {
-        $("a#btn-qdown").attr("href", "data:text/plain;charset=UTF-8," + encodeURIComponent($("#uploadedQuery").text()));
+    // Download query action
+    $("span#btn-qdown").click(function() {
+        var service = new RestServiceJs("results");
+        var jdata = prepareQuery(0, 0, true);
+        service.post(jdata,function(data) {
+            downloadTextAsFile("query.sparql", data.query);
+        });
     });
 
     // Get the overview of files to integrate

--- a/askomics/static/js/askomics.js
+++ b/askomics/static/js/askomics.js
@@ -159,16 +159,16 @@ function hideModal(){
 
 function downloadTextAsFile(filename, text) {
     // Download text as file
-  var element = document.createElement('a');
-  element.setAttribute('href', 'data:text/plain;charset=utf-8,' + encodeURIComponent(text));
-  element.setAttribute('download', filename);
+    var element = document.createElement('a');
+    element.setAttribute('href', 'data:text/plain;charset=utf-8,' + encodeURIComponent(text));
+    element.setAttribute('download', filename);
 
-  element.style.display = 'none';
-  document.body.appendChild(element);
+    element.style.display = 'none';
+    document.body.appendChild(element);
 
-  element.click();
+    element.click();
 
-  document.body.removeChild(element);
+    document.body.removeChild(element);
 }
 
 

--- a/askomics/static/js/graph.js
+++ b/askomics/static/js/graph.js
@@ -116,8 +116,6 @@ function detailsOf(elemUri, elemId, attributes, nameDiv, data) {
 
           //  console.log(attributes[i].uri);
             service.post(model, function(d) {
-              //  var datalist = $("<datalist></datalist>").attr("id", "opt_" + id);
-                inp.append($("<option></option>").attr("value", "").attr("selected", "selected"));
                 var sizeSelect = 3 ;
                 if ( d.value.length<3 ) sizeSelect = d.value.length;
                 if ( d.value.length === 0 ) sizeSelect = 1;
@@ -131,7 +129,6 @@ function detailsOf(elemUri, elemId, attributes, nameDiv, data) {
                 } else if (d.value.length == 1) {
                   inp.append($("<option></option>").attr("value", d.value[0]).append(d.value[0]));
                 }
-              //  inp.append(datalist);
               hideModal();
             });
         } else {
@@ -164,7 +161,13 @@ function detailsOf(elemUri, elemId, attributes, nameDiv, data) {
                 .addClass('glyphicon-eye-close')
                 .addClass('display');
 
-        details.append(lab).append(icon).append(inp);
+        var removeIcon = $('<span class="glyphicon glyphicon-remove display"></span>');
+        removeIcon.click(function() { inp.val(null).trigger("change"); });
+
+        details.append(lab)
+               .append(icon)
+               .append(removeIcon)
+               .append(inp);
 
         inp.change(function() {
             var value = $(this).find('#'+id).val();
@@ -181,7 +184,7 @@ function detailsOf(elemUri, elemId, attributes, nameDiv, data) {
             removeFilterNum(id);
             removeFilterStr(id);
 
-            if (value === "") {
+            if (value === "" || value === null) {
                 if (!isDisplayed(id)) {
                     removeConstraint(id);
 
@@ -626,9 +629,6 @@ function myGraph() {
 
                         if (prev_data)
                             hideSuggestions(prev_data.id); // Hide suggestions on previous node
-
-                        // save the query in the download button
-                        launchQuery(0, 30, true);
                     });
                 });
 

--- a/askomics/static/js/graph.js
+++ b/askomics/static/js/graph.js
@@ -67,6 +67,12 @@ function insertSuggestions(prev_node, slt_node, expansionDict, nodeList, linkLis
     $("#svgdiv").data({ last_counter: expansionDict.last_counter, last_new_counter : expansionDict.last_new_counter });
 }
 
+function makeRemoveIcon(field) {
+    var removeIcon = $('<span class="glyphicon glyphicon-remove display"></span>');
+    removeIcon.click(function() { field.val(null).trigger("change"); });
+    return removeIcon;
+}
+
 function detailsOf(elemUri, elemId, attributes, nameDiv, data) {
     // Add attributes of the selected node on the right side of AskOmics
 
@@ -84,7 +90,9 @@ function detailsOf(elemUri, elemId, attributes, nameDiv, data) {
         var nameLab = $("<label></label>").attr("for",elemId).text("Name");
         var nameInp = $("<input/>").attr("id", "lab_" + elemId).addClass("form-control");
 
-        details.append(nameLab).append(nameInp);
+        details.append(nameLab)
+               .append(makeRemoveIcon(nameInp))
+               .append(nameInp);
 
         nameInp.change(function(d) {
             var value = $(this).val();
@@ -146,7 +154,8 @@ function detailsOf(elemUri, elemId, attributes, nameDiv, data) {
 
               tr = $("<tr></tr>");
               tr.append($("<td></td>").append(v));
-              v = $("<input/>").attr("id",id).attr("type", "text").addClass("form-control");
+              v = $('<input type="text" class="form-control"/>').attr("id",id);
+              inp.val = v.val.bind(v);
               tr.append($("<td></td>").append(v));
               inp.append(tr);
             } else {
@@ -161,12 +170,9 @@ function detailsOf(elemUri, elemId, attributes, nameDiv, data) {
                 .addClass('glyphicon-eye-close')
                 .addClass('display');
 
-        var removeIcon = $('<span class="glyphicon glyphicon-remove display"></span>');
-        removeIcon.click(function() { inp.val(null).trigger("change"); });
-
         details.append(lab)
+               .append(makeRemoveIcon(inp))
                .append(icon)
-               .append(removeIcon)
                .append(inp);
 
         inp.change(function() {

--- a/askomics/static/js/query-handler.js
+++ b/askomics/static/js/query-handler.js
@@ -172,53 +172,51 @@ function delFromQuery(id) {
     removeFilterStr(id);
 }
 
-function formatQuery() {
-    $("input[type='checkbox']:checked").each(function() {
-        addDisplay($(this).attr('name'));
-    });
-    launchQuery(0, 30, false);
-}
 
-function launchQuery(exp, lim, roq) {
-    //     Get SPARQL query corresponding to the graph and launch it according
-    //     to given parameters.
+
+
+function prepareQuery(exp, lim, roq) {
+    //     Get JSON to ask for a SPARQL query corresponding to the graph
+    //     and launch it according to given parameters.
     //
     //     :exp: 0 = results overview
     //           1 = complete results file generation
     //     :lim: LIMIT value in the SPARQL query
     //     :roq: bool, if true, don't launch the query, only return it
+    return { 'display':display,
+              'constraint':constraint,
+              'filter_cat':filter_cat,
+              'filter_num':filter_num,
+              'filter_str':filter_str,
+              'export':exp,
+              'limit':lim,
+              'return_only_query':roq,
+              'uploaded':$("#uploadedQuery").text()
+          };
+}
 
-    if (exp == 1) {
-        $("#export").remove();
-        $("#btn-file").text("Generating results file, please wait...");
-        $("#btn-file").disabled = true;
-    }
-
-    if (!roq)
-      displayModal('Please wait', 'Close');
-
-    var jdata = { 'display':display,
-                  'constraint':constraint,
-                  'filter_cat':filter_cat,
-                  'filter_num':filter_num,
-                  'filter_str':filter_str,
-                  'export':exp,
-                  'limit':lim,
-                  'return_only_query':roq,
-                  'uploaded':$("#uploadedQuery").text() };
+function viewQueryResults() {
+    displayModal('Please wait', 'Close');
 
     var service = new RestServiceJs("results");
-
+    var jdata = prepareQuery(0, 30, false);
     service.post(jdata,function(data) {
-        if (roq) {
-            $("a#btn-qdown").attr("href", "data:text/plain;charset=UTF-8," + encodeURIComponent(data.query));
-        } else if (exp === 0) {
-            displayResults(data);
-            hideModal();
-        } else {
-            provideDownloadLink(data);
-            hideModal();
-        }
+        displayResults(data);
+        hideModal();
+    });
+}
+
+function generateResultFile(lim) {
+    displayModal('Please wait', 'Close');
+    $("#export").remove();
+    $("#btn-file").text("Generating results file, please wait...");
+    $("#btn-file").disabled = true;
+
+    var service = new RestServiceJs("results");
+    var jdata = prepareQuery(1, lim, false);
+    service.post(jdata, function(data) {
+        provideDownloadLink(data);
+        hideModal();
     });
 }
 

--- a/askomics/templates/index.pt
+++ b/askomics/templates/index.pt
@@ -61,7 +61,7 @@
                         <input id="uploadBtn" type="file" class="upload">
                     </div>
                     <div class="btn-group btn-group-query">
-                        <a id="btn-qdown" type="button" class="btn btn-default" href="" download="query.sparql">Download query</a>
+                        <span id="btn-qdown" class="btn btn-default">Download query</span>
                     </div>
                     <div id="svgdiv"></div>
                     <div id="uploadedQuery" class="uploadedQuery" hidden contenteditable></div>
@@ -70,12 +70,12 @@
                             <button id="btn-down" type="submit" class="btn btn-default">
                                 <span class="glyphicon glyphicon-save"></span>
                             </button>
-                            <button id="btn-file" type="button" class="btn btn-default" onclick="launchQuery(1,10000, false)">
+                            <button id="btn-file" type="button" class="btn btn-default" onclick="generateResultFile(10000)">
                                 Generate a results file (max 10000 lines)
                             </button>
                         </div>
                         <div class="btn-group btn-group-query">
-                            <button type="button" class="btn btn-default" onclick="formatQuery()">Launch query</button>
+                            <button type="button" class="btn btn-default" onclick="viewQueryResults()">Launch query</button>
                             <button type="button" class="btn btn-default" onclick="window.location.reload()">Reset</button>
                         </div>
                     </form>


### PR DESCRIPTION
Fix the incomplete query made when pressing the Download query button. Now VALUES and FILTER are contained in the query.

Also during request on AskOmics, when the user select attributes of category present in the right panel and deselect them and then select the empty value in the panel (to select all the value of this category), the request created was incorrect (it's displayed no result). 
This fix delete the empty attribute in the category selection panel and add a cross (at the left of the eye enabling category). When clicking on the cross it deselect all the previous attributes (allowing request on all attributes of the category).