### PR TITLE
New start script

### DIFF
--- a/configs/development.agraph.ini
+++ b/configs/development.agraph.ini
@@ -28,8 +28,13 @@ pyramid.includes =
 # '127.0.0.1' and '::1'.
 # debugtoolbar.hosts = 127.0.0.1 ::1
 
-# Le graph Askomics. Peux etre modifie pour la gestion de plusieurs bdd
-askomics.graph=urn:sparql:tests-askomics:insert:informative1
+# Askomics graphs. Can be modified to handle several databases
+askomics.graph=urn:sparql:askomics
+# Public and private graphs are subgraph of askomics graph
+askomics.public_graph=urn:sparql:askomics:public
+askomics.private_graph=urn:sparql:askomics:private
+# Users graph contain infos about users. subgraph of akomics graph
+askomics.users_graph=urn:sparql:askomics:users
 
 askomics.prefix = http://www.semanticweb.org/irisa/ontologies/2016/1/igepp-ontology#
 askomics.display_setting = http://www.irisa.fr/dyliss/rdfVisualization/display
@@ -59,7 +64,7 @@ askomics.proxy_password = password
 
 [server:main]
 use = egg:waitress#main
-host = 0.0.0.0
+host = localhost
 port = 6543
 
 ###

--- a/configs/development.corese.ini
+++ b/configs/development.corese.ini
@@ -20,8 +20,13 @@ askomics.debug = true
 # '127.0.0.1' and '::1'.
 # debugtoolbar.hosts = 127.0.0.1 ::1
 
-# Le graph Askomics. Peux etre modifie pour la gestion de plusieurs bdd
-askomics.graph=urn:sparql:tests-askomics:insert:informative1
+# Askomics graphs. Can be modified to handle several databases
+askomics.graph=urn:sparql:askomics
+# Public and private graphs are subgraph of askomics graph
+askomics.public_graph=urn:sparql:askomics:public
+askomics.private_graph=urn:sparql:askomics:private
+# Users graph contain infos about users. subgraph of akomics graph
+askomics.users_graph=urn:sparql:askomics:users
 
 askomics.endpoint = http://localhost:8080/sparql
 askomics.max_content_size_to_update_database=500000
@@ -44,7 +49,7 @@ askomics.delete_method = DELETE
 
 [server:main]
 use = egg:waitress#main
-host = 0.0.0.0
+host = localhost
 port = 6543
 
 ###

--- a/configs/development.fuseki.ini
+++ b/configs/development.fuseki.ini
@@ -29,8 +29,13 @@ pyramid.includes =
 # '127.0.0.1' and '::1'.
 # debugtoolbar.hosts = 127.0.0.1 ::1
 
-# Le graph Askomics. Peux etre modifie pour la gestion de plusieurs bdd
-askomics.graph=urn:sparql:tests-askomics:insert:informative1
+# Askomics graphs. Can be modified to handle several databases
+askomics.graph=urn:sparql:askomics
+# Public and private graphs are subgraph of askomics graph
+askomics.public_graph=urn:sparql:askomics:public
+askomics.private_graph=urn:sparql:askomics:private
+# Users graph contain infos about users. subgraph of akomics graph
+askomics.users_graph=urn:sparql:askomics:users
 
 askomics.prefix = http://www.semanticweb.org/irisa/ontologies/2016/1/igepp-ontology#
 askomics.display_setting = http://www.irisa.fr/dyliss/rdfVisualization/display
@@ -60,7 +65,7 @@ askomics.proxy_password = password
 
 [server:main]
 use = egg:waitress#main
-host = 0.0.0.0
+host = localhost
 port = 6543
 
 ###

--- a/configs/development.ini
+++ b/configs/development.ini
@@ -33,8 +33,13 @@ askomics.secret = seppfmhcag
 ### (if needed) askomics.endpoint.passwd : user passord
 ### (if needed) askomics.endpoint.auth : 'Basic' or 'Digest'
 
-# Le graph Askomics. Peux etre modifie pour la gestion de plusieurs bdd
-askomics.graph=urn:sparql:tests-askomics:insert:informative1
+# Askomics graphs. Can be modified to handle several databases
+askomics.graph=urn:sparql:askomics
+# Public and private graphs are subgraph of askomics graph
+askomics.public_graph=urn:sparql:askomics:public
+askomics.private_graph=urn:sparql:askomics:private
+# Users graph contain infos about users. subgraph of akomics graph
+askomics.users_graph=urn:sparql:askomics:users
 
 # Exec service :
 # sudo docker run --name fuseki -p 3030:3030 -t askomics/fuseki-2.3.1:latest
@@ -111,7 +116,7 @@ askomics.proxy_password = password
 
 [server:main]
 use = egg:waitress#main
-host = 0.0.0.0
+host = localhost
 port = 6543
 
 ###

--- a/configs/development.virtuoso.ini
+++ b/configs/development.virtuoso.ini
@@ -64,7 +64,7 @@ askomics.proxy_password = password
 
 [server:main]
 use = egg:waitress#main
-host = 0.0.0.0
+host = localhost
 port = 6543
 
 ###

--- a/configs/production.agraph.ini
+++ b/configs/production.agraph.ini
@@ -22,8 +22,13 @@ pyramid.default_locale_name = en
 askomics.salt = AskOmics
 askomics.secret = seppfmhcag
 
-# Le graph Askomics. Peux etre modifie pour la gestion de plusieurs bdd
-askomics.graph=urn:sparql:tests-askomics:insert:informative1
+# Askomics graphs. Can be modified to handle several databases
+askomics.graph=urn:sparql:askomics
+# Public and private graphs are subgraph of askomics graph
+askomics.public_graph=urn:sparql:askomics:public
+askomics.private_graph=urn:sparql:askomics:private
+# Users graph contain infos about users. subgraph of akomics graph
+askomics.users_graph=urn:sparql:askomics:users
 
 askomics.prefix = http://www.semanticweb.org/irisa/ontologies/2016/1/igepp-ontology#
 askomics.display_setting = http://www.irisa.fr/dyliss/rdfVisualization/display
@@ -53,7 +58,7 @@ askomics.proxy_password = password
 
 [server:main]
 use = egg:waitress#main
-host = 0.0.0.0
+host = localhost
 port = 6543
 
 ###

--- a/configs/production.fuseki.ini
+++ b/configs/production.fuseki.ini
@@ -23,8 +23,13 @@ pyramid.default_locale_name = en
 askomics.salt = AskOmics
 askomics.secret = seppfmhcag
 
-# Le graph Askomics. Peux etre modifie pour la gestion de plusieurs bdd
-askomics.graph=urn:sparql:tests-askomics:insert:informative1
+# Askomics graphs. Can be modified to handle several databases
+askomics.graph=urn:sparql:askomics
+# Public and private graphs are subgraph of askomics graph
+askomics.public_graph=urn:sparql:askomics:public
+askomics.private_graph=urn:sparql:askomics:private
+# Users graph contain infos about users. subgraph of akomics graph
+askomics.users_graph=urn:sparql:askomics:users
 
 askomics.prefix = http://www.semanticweb.org/irisa/ontologies/2016/1/igepp-ontology#
 askomics.display_setting = http://www.irisa.fr/dyliss/rdfVisualization/display
@@ -54,7 +59,7 @@ askomics.proxy_password = password
 
 [server:main]
 use = egg:waitress#main
-host = 0.0.0.0
+host = localhost
 port = 6543
 
 ###

--- a/configs/production.ini
+++ b/configs/production.ini
@@ -20,8 +20,13 @@ pyramid.default_locale_name = en
 askomics.salt = AskOmics
 askomics.secret = seppfmhcag
 
-# Le graph Askomics. Peux etre modifie pour la gestion de plusieurs bdd
-askomics.graph=urn:sparql:tests-askomics:insert:informative1
+# Askomics graphs. Can be modified to handle several databases
+askomics.graph=urn:sparql:askomics
+# Public and private graphs are subgraph of askomics graph
+askomics.public_graph=urn:sparql:askomics:public
+askomics.private_graph=urn:sparql:askomics:private
+# Users graph contain infos about users. subgraph of akomics graph
+askomics.users_graph=urn:sparql:askomics:users
 
 askomics.prefix = http://www.semanticweb.org/irisa/ontologies/2016/1/igepp-ontology#
 askomics.display_setting = http://www.irisa.fr/dyliss/rdfVisualization/display
@@ -51,7 +56,7 @@ askomics.proxy_password = password
 
 [server:main]
 use = egg:waitress#main
-host = 0.0.0.0
+host = localhost
 port = 6543
 
 ###

--- a/configs/production.virtuoso.ini
+++ b/configs/production.virtuoso.ini
@@ -20,8 +20,13 @@ pyramid.default_locale_name = en
 askomics.salt = AskOmics
 askomics.secret = seppfmhcag
 
-# Le graph Askomics. Peux etre modifie pour la gestion de plusieurs bdd
-askomics.graph=urn:sparql:tests-askomics:insert:informative1
+# Askomics graphs. Can be modified to handle several databases
+askomics.graph=urn:sparql:askomics
+# Public and private graphs are subgraph of askomics graph
+askomics.public_graph=urn:sparql:askomics:public
+askomics.private_graph=urn:sparql:askomics:private
+# Users graph contain infos about users. subgraph of akomics graph
+askomics.users_graph=urn:sparql:askomics:users
 
 askomics.prefix = http://www.semanticweb.org/irisa/ontologies/2016/1/igepp-ontology#
 askomics.display_setting = http://www.irisa.fr/dyliss/rdfVisualization/display
@@ -51,7 +56,7 @@ askomics.proxy_password = password
 
 [server:main]
 use = egg:waitress#main
-host = 0.0.0.0
+host = localhost
 port = 6543
 
 ###

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,96 @@
+#! /bin/bash
+
+############################################
+#                                          #
+#             AskOmics laucher             #
+#                                          #
+############################################
+
+
+function usage {
+    echo "Options:"
+    echo "    -t <triplestore>: the triplestore, default is virtuoso"
+    echo "    -m <mode>: dev or prod, default is dev"
+    echo ""
+    echo "    -d <askomics directory>, default is script directory"
+    echo "    -r : reload askomics when a file is modified"
+    echo "    -h : print this help"
+    exit 0
+}
+
+
+#Default option:
+triplestore='virtuoso'
+depmode='development'
+gulpmode=''
+# path=$(pwd)
+path=$(dirname "$0")
+arg='--reload'
+
+
+# options
+while getopts "t:m:d:rh" opt ; do
+    case $opt in
+        t)
+            triplestore=$OPTARG
+        ;;
+        m)
+            case $OPTARG in
+                prod|production)
+                    depmode="production"
+                    gulpmode="--prod"
+                ;;
+                dev|development)
+                    depmode="development"
+                    gulpmode=""
+                ;;
+                *)
+                    usage
+                ;;
+            esac
+        ;;
+        d)
+            path=$OPTARG
+        ;;
+        r)
+            arg='--reload'
+        ;;
+        h)
+
+            usage
+        ;;
+    esac
+done
+
+config_file="$depmode.$triplestore.ini"
+config_path="$path/configs/$config_file"
+
+if [[ ! -f $config_path ]]; then
+    echo "config file $config_path not found"
+    exit 1
+fi
+
+# lauch gulp
+echo "build javascript"
+# gulp $gulpmode
+
+# build the venv
+activate_path="$path/venv/bin/activate"
+
+if [[ ! -f $activate_path ]]; then
+    echo "building python virtual environement in $activate_path"
+    # python3 -m ensurepip
+    python3 -m venv $path/venv
+    source $activate_path
+    python3 -m pip install -e .
+else
+    echo "activate the virtual environment ..."
+    source $activate_path
+    
+fi
+
+
+source $activate_path
+
+echo "lauch AskOmics"
+python3 $path/venv/bin/pserve $config_path $arg


### PR DESCRIPTION
Usage:

    ./start.sh -t <triplestore> -m <mode>

With:
triplestore: virtuoso, fuseki ... (for the config file to use. don't lauch a triplestore)
mode: production or development

Other option:
-r : reload when a python file is modified
-h: print the help

The script build the venv is not exist




EDIT:
 And update all config files with the new graph and localhost instead of 0.0.0.0