### PR TITLE
Administration and account managment

### DIFF
--- a/askomics/__init__.py
+++ b/askomics/__init__.py
@@ -61,6 +61,8 @@ def main(global_config, **settings):
     config.add_route('setAdmin', '/setAdmin')
     config.add_route('delete_user', '/delete_user')
 
+    config.add_route('get_my_infos', 'get_my_infos')
+
 
     # TODO no absolute path to static files
     # TODO check what is cors (iframe redirect?)

--- a/askomics/__init__.py
+++ b/askomics/__init__.py
@@ -59,6 +59,7 @@ def main(global_config, **settings):
     config.add_route('get_users_infos', '/get_users_infos')
     config.add_route('lockUser', '/lockUser')
     config.add_route('setAdmin', '/setAdmin')
+    config.add_route('delete_user', '/delete_user')
 
 
     # TODO no absolute path to static files

--- a/askomics/__init__.py
+++ b/askomics/__init__.py
@@ -62,6 +62,7 @@ def main(global_config, **settings):
     config.add_route('delete_user', '/delete_user')
 
     config.add_route('get_my_infos', 'get_my_infos')
+    config.add_route('update_mail', 'update_mail')
 
 
     # TODO no absolute path to static files

--- a/askomics/__init__.py
+++ b/askomics/__init__.py
@@ -63,6 +63,7 @@ def main(global_config, **settings):
 
     config.add_route('get_my_infos', 'get_my_infos')
     config.add_route('update_mail', 'update_mail')
+    config.add_route('update_passwd', 'update_passwd')
 
 
     # TODO no absolute path to static files

--- a/askomics/__init__.py
+++ b/askomics/__init__.py
@@ -57,6 +57,8 @@ def main(global_config, **settings):
 
     # Administration
     config.add_route('get_users_infos', '/get_users_infos')
+    config.add_route('lockUser', '/lockUser')
+    config.add_route('setAdmin', '/setAdmin')
 
 
     # TODO no absolute path to static files

--- a/askomics/ask_view.py
+++ b/askomics/ask_view.py
@@ -1098,10 +1098,19 @@ class AskView(object):
         body = self.request.json_body
 
         username = body['username']
+        passwd = body['passwd']
+        confirmation = body['passwd_conf']
 
         # Non admin can only delete himself
         if self.request.session['username'] != username and not self.request.session['admin']:
             return 'forbidden'
+
+        # If confirmation, check the user passwd
+        if confirmation:
+            security = Security(self.settings, self.request.session, username, '', passwd, passwd)
+            if not security.check_username_password():
+                self.data['error'] = 'Wrong password'
+                return self.data
 
 
         sqb = SparqlQueryBuilder(self.settings, self.request.session)

--- a/askomics/ask_view.py
+++ b/askomics/ask_view.py
@@ -52,6 +52,9 @@ class AskView(object):
             if 'admin' not in self.request.session.keys():
                 self.request.session['admin'] = False
 
+            if 'blocked' not in self.request.session.keys():
+                self.request.session['blocked'] = True
+
             if 'group' not in self.request.session.keys():
                 self.request.session['group'] = ''
 
@@ -119,6 +122,10 @@ class AskView(object):
         # Denny access for non loged users
         if self.request.session['username'] == '':
             return 'forbidden'
+
+        # Denny for blocked users
+        if self.request.session['blocked']:
+            return 'blocked'
 
         self.log.debug('=== stats ===')
 
@@ -227,6 +234,10 @@ class AskView(object):
         if self.request.session['username'] == '':
             return 'forbidden'
 
+        # Denny for blocked users
+        if self.request.session['blocked']:
+            return 'blocked'
+
         self.log.debug("=== DELETE ALL NAMED GRAPHS ===")
 
         try:
@@ -258,6 +269,10 @@ class AskView(object):
         if self.request.session['username'] == '':
             return 'forbidden'
 
+        # Denny for blocked users
+        if self.request.session['blocked']:
+            return 'blocked'
+
         self.log.debug("=== DELETE SELECTED GRAPHS ===")
 
         sqb = SparqlQueryBuilder(self.settings, self.request.session)
@@ -280,6 +295,10 @@ class AskView(object):
         # Denny access for non loged users
         if self.request.session['username'] == '':
             return 'forbidden'
+
+        # Denny for blocked users
+        if self.request.session['blocked']:
+            return 'blocked'
 
         self.log.debug("=== LIST OF NAMED GRAPHS ===")
 
@@ -340,6 +359,10 @@ class AskView(object):
         # Denny access for non loged users
         if self.request.session['username'] == '':
             return 'forbidden'
+
+        # Denny for blocked users
+        if self.request.session['blocked']:
+            return 'blocked'
 
         self.log.debug(" ========= Askview:source_files_overview =============")
         sfc = SourceFileConvertor(self.settings, self.request.session)
@@ -410,6 +433,10 @@ class AskView(object):
         if self.request.session['username'] == '':
             return 'forbidden'
 
+        # Denny for blocked users
+        if self.request.session['blocked']:
+            return 'blocked'
+
 
         self.log.debug("preview_ttl")
 
@@ -467,6 +494,10 @@ class AskView(object):
         if self.request.session['username'] == '':
             return 'forbidden'
 
+        # Denny for blocked users
+        if self.request.session['blocked']:
+            return 'blocked'
+
         body = self.request.json_body
         file_name = body["file_name"]
         col_types = body["col_types"]
@@ -502,6 +533,10 @@ class AskView(object):
         # Denny access for non loged users
         if self.request.session['username'] == '':
             return 'forbidden'
+
+        # Denny for blocked users
+        if self.request.session['blocked']:
+            return 'blocked'
 
         body = self.request.json_body
         file_name = body["file_name"]
@@ -542,6 +577,10 @@ class AskView(object):
         if self.request.session['username'] == '':
             return 'forbidden'
 
+        # Denny for blocked users
+        if self.request.session['blocked']:
+            return 'blocked'
+
 
         self.log.debug("== load_gff_into_graph ==")
 
@@ -580,6 +619,10 @@ class AskView(object):
         # Denny access for non loged users
         if self.request.session['username'] == '':
             return 'forbidden'
+
+        # Denny for blocked users
+        if self.request.session['blocked']:
+            return 'blocked'
 
 
         self.log.debug('*** load_ttl_into_graph ***')
@@ -624,6 +667,10 @@ class AskView(object):
         if self.request.session['username'] == '' or not self.request.session['admin'] :
             return 'forbidden'
 
+        # Denny for blocked users
+        if self.request.session['blocked']:
+            return 'blocked'
+
         self.log.debug('*** importShortcut ***')
 
         body = self.request.json_body
@@ -652,6 +699,10 @@ class AskView(object):
         # Denny access for non loged users
         if self.request.session['username'] == '' or not self.request.session['admin'] :
             return 'forbidden'
+
+        # Denny for blocked users
+        if self.request.session['blocked']:
+            return 'blocked'
 
         self.log.debug('*** importShortcut ***')
 
@@ -808,6 +859,9 @@ class AskView(object):
         try:
             security.log_user(self.request)
             self.data['username'] = username
+            admin_blocked = security.get_admin_blocked_by_username()
+            self.data['admin'] = admin_blocked['admin']
+            self.data['blocked'] = admin_blocked['blocked']
         except Exception as e:
             self.data['error'] = traceback.format_exc(limit=8)+"\n\n\n"+str(e)
             self.log.error(str(e))
@@ -820,6 +874,7 @@ class AskView(object):
         if self.request.session['username'] != '':
             self.data['username'] = self.request.session['username']
             self.data['admin'] = self.request.session['admin']
+            self.data['blocked'] = self.request.session['blocked']
 
         return self.data
 
@@ -927,6 +982,10 @@ class AskView(object):
         # Denny access for non loged users or non admin users
         if self.request.session['username'] == '' or not self.request.session['admin']:
             return 'forbidden'
+
+        # Denny for blocked users
+        if self.request.session['blocked']:
+            return 'blocked'
 
         sqa = SparqlQueryAuth(self.settings, self.request.session)
         ql = QueryLauncher(self.settings, self.request.session)

--- a/askomics/ask_view.py
+++ b/askomics/ask_view.py
@@ -872,9 +872,10 @@ class AskView(object):
                 self.data['error'].append('Password is incorrect')
                 error = True
 
-            # Get the admin status
-            admin = security.get_admin_status_by_email()
-            security.set_admin(admin)
+            # Get the admin and blocked status
+            admin_blocked = security.get_admin_blocked_by_email()
+            security.set_admin(admin_blocked['admin'])
+            security.set_blocked(admin_blocked['blocked'])
 
             if error:
                 return self.data
@@ -886,9 +887,10 @@ class AskView(object):
                 self.data['error'].append('username is not registered')
                 error = True
 
-            # Get the admin status
-            admin = security.get_admin_status_by_username()
-            security.set_admin(admin)
+            # Get the admin and blocked status
+            admin_blocked = security.get_admin_blocked_by_username()
+            security.set_admin(admin_blocked['admin'])
+            security.set_blocked(admin_blocked['blocked'])
 
             if error:
                 return self.data
@@ -906,7 +908,8 @@ class AskView(object):
         try:
             security.log_user(self.request)
             self.data['username'] = username
-            self.data['admin'] = admin
+            self.data['admin'] = admin_blocked['admin']
+            self.data['blocked'] = admin_blocked['blocked']
 
         except Exception as e:
             self.data['error'] = str(e)

--- a/askomics/ask_view.py
+++ b/askomics/ask_view.py
@@ -991,7 +991,7 @@ class AskView(object):
         ql = QueryLauncher(self.settings, self.request.session)
 
         try:
-            result = ql.process_query(sqa.get_users_infos().query)
+            result = ql.process_query(sqa.get_users_infos(self.request.session['username']).query)
         except Exception as e:
             self.data['error'] = str(e)
             self.log.error(str(e))

--- a/askomics/ask_view.py
+++ b/askomics/ask_view.py
@@ -1165,8 +1165,6 @@ class AskView(object):
         Chage email of a user
         """
 
-        self.data['error'] = []
-
         body = self.request.json_body
         username = body['username']
         email = body['email']
@@ -1176,13 +1174,47 @@ class AskView(object):
         security = Security(self.settings, self.request.session, username, email, '', '')
 
         if not security.check_email():
-            self.data['error'].append('Not a valid email')
+            self.data['error'] = 'Not a valid email'
             return self.data
 
         try:
             security.update_email()
         except Exception as e:
-            self.data['error'].append('error when updating mail: ' + str(e))
+            self.data['error'] = 'error when updating mail: ' + str(e)
+            return self.data
+
+        self.data['success'] = 'success'
+
+        return self.data
+
+    @view_config(route_name='update_passwd', request_method='POST')
+    def update_passwd(self):
+        """
+        Chage email of a user
+        """
+
+        body = self.request.json_body
+        username = body['username']
+        passwd = body['passwd']
+        passwd2 = body['passwd2']
+
+        security = Security(self.settings, self.request.session, username, '', passwd, passwd2)
+
+
+        # check if the passwd are identical
+        if not security.check_passwords():
+            self.data['error'] = 'Passwords are not identical'
+            return self.data
+
+        if not security.check_password_length():
+            self.data['error'] = 'Password is too small (8char min)'
+            return self.data
+
+
+        try:
+            security.update_passwd()
+        except Exception as e:
+            self.data['error'] = 'error when updating password: ' + str(e)
             return self.data
 
         self.data['success'] = 'success'

--- a/askomics/ask_view.py
+++ b/askomics/ask_view.py
@@ -1197,6 +1197,13 @@ class AskView(object):
         username = body['username']
         passwd = body['passwd']
         passwd2 = body['passwd2']
+        current_passwd = body['current_passwd']
+
+        security1 = Security(self.settings, self.request.session, username, '', current_passwd, current_passwd)
+
+        if not security1.check_username_password():
+            self.data['error'] = 'Current password is wrong'
+            return self.data
 
         security = Security(self.settings, self.request.session, username, '', passwd, passwd2)
 

--- a/askomics/ask_view.py
+++ b/askomics/ask_view.py
@@ -1159,3 +1159,32 @@ class AskView(object):
         result['blocked'] = bool(int(result['blocked']))
 
         return result
+    @view_config(route_name='update_mail', request_method='POST')
+    def update_mail(self):
+        """
+        Chage email of a user
+        """
+
+        self.data['error'] = []
+
+        body = self.request.json_body
+        username = body['username']
+        email = body['email']
+
+        # Check email
+
+        security = Security(self.settings, self.request.session, username, email, '', '')
+
+        if not security.check_email():
+            self.data['error'].append('Not a valid email')
+            return self.data
+
+        try:
+            security.update_email()
+        except Exception as e:
+            self.data['error'].append('error when updating mail: ' + str(e))
+            return self.data
+
+        self.data['success'] = 'success'
+
+        return self.data

--- a/askomics/libaskomics/Security.py
+++ b/askomics/libaskomics/Security.py
@@ -299,3 +299,12 @@ class Security(ParamManager):
         self.log.debug('------------------------ sha256 password -----------------------')
         self.log.debug(self.sha256_pw)
         self.log.debug('----------------------------------------------------------------')
+
+    def update_email(self):
+        """
+
+        """
+        query_laucher = QueryLauncher(self.settings, self.session)
+        sqa = SparqlQueryAuth(self.settings, self.session)
+
+        res = query_laucher.process_query(sqa.update_mail(self.username, self.email).query)

--- a/askomics/libaskomics/Security.py
+++ b/askomics/libaskomics/Security.py
@@ -30,7 +30,7 @@ class Security(ParamManager):
         # see --"https://en.wikipedia.org/wiki/Salt_(cryptography)"-- for more info about salt
         alpabet = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
         self.randomsalt = ''.join(random.choice(alpabet) for i in range(20))
-        salted_pw = self.settings["askomics.salt"] + password + self.randomsalt
+        salted_pw = self.settings["askomics.salt"] + self.passwd + self.randomsalt
         self.sha256_pw = hashlib.sha256(salted_pw.encode('utf8')).hexdigest()
 
     def check_email(self):
@@ -302,9 +302,18 @@ class Security(ParamManager):
 
     def update_email(self):
         """
-
+        change the mail of a user
         """
         query_laucher = QueryLauncher(self.settings, self.session)
         sqa = SparqlQueryAuth(self.settings, self.session)
 
-        res = query_laucher.process_query(sqa.update_mail(self.username, self.email).query)
+        query_laucher.process_query(sqa.update_mail(self.username, self.email).query)
+
+    def update_passwd(self):
+        """
+        Change the password of a user, and his randomsalt
+        """
+        query_laucher = QueryLauncher(self.settings, self.session)
+        sqa = SparqlQueryAuth(self.settings, self.session)
+
+        query_laucher.process_query(sqa.update_passwd(self.username, self.sha256_pw, self.randomsalt).query)

--- a/askomics/libaskomics/rdfdb/SparqlQueryAuth.py
+++ b/askomics/libaskomics/rdfdb/SparqlQueryAuth.py
@@ -106,7 +106,7 @@ class SparqlQueryAuth(SparqlQueryBuilder):
                      "}"
         }, True)
 
-    def get_users_infos(self, me):
+    def get_users_infos(self, username):
         """
         Get users infos exept me
         """
@@ -118,7 +118,22 @@ class SparqlQueryAuth(SparqlQueryBuilder):
                      '\t?URIusername foaf:mbox ?email .\n' +
                      '\t?URIusername :isadmin ?admin .\n'+
                      '\t?URIusername :isblocked ?blocked .' +
-                     '\tFILTER NOT EXISTS { ?URIusername foaf:name "' + me + '" . }\n' +
+                     '\tFILTER NOT EXISTS { ?URIusername foaf:name "' + username + '" . }\n' +
+                     "}"
+        }, True)
+
+    def get_user_infos(self, username):
+        """
+        Get infos about one user
+        """
+        return self.build_query_on_the_fly({
+            'select': '?username ?email ?admin ?blocked',
+            'query': "GRAPH <"+ self.get_param("askomics.users_graph") + "> {" +
+                     '\t?URIusername rdf:type foaf:Person .\n' +
+                     '\t?URIusername foaf:name "' + username + '" .\n' +
+                     '\t?URIusername foaf:mbox ?email .\n' +
+                     '\t?URIusername :isadmin ?admin .\n'+
+                     '\t?URIusername :isblocked ?blocked .' +
                      "}"
         }, True)
 

--- a/askomics/libaskomics/rdfdb/SparqlQueryAuth.py
+++ b/askomics/libaskomics/rdfdb/SparqlQueryAuth.py
@@ -149,3 +149,29 @@ class SparqlQueryAuth(SparqlQueryBuilder):
                      '\t?URIusername :isadmin "true"^^xsd:boolean .\n'+
                      "}"
         }, True)
+
+    def update_mail(self, username, email):
+        """
+        update the email of user
+        """
+        return self.prepare_query(
+            """
+            WITH GRAPH <""" + self.get_param('askomics.users_graph') + """>
+            DELETE { :""" + username + """ foaf:mbox ?email }
+            INSERT { :""" + username + """ foaf:mbox <mailto:""" + email + """> }
+            WHERE { :""" + username + """ foaf:mbox ?email }
+            """)
+
+
+
+    # def update_admin_status(self, admin, username):
+    #     """
+    #     Change the admin status of a user!
+    #     """
+    #     return self.prepare_query(
+    #         """
+    #         WITH GRAPH <""" + self.get_param('askomics.users_graph') + """>
+    #         DELETE { :""" + username + """ :isadmin ?admin }
+    #         INSERT { :""" + username + """ :isadmin \"""" + admin + """\"^^xsd:boolean }
+    #         WHERE { :""" + username + """ :isadmin ?admin }
+    #         """)

--- a/askomics/libaskomics/rdfdb/SparqlQueryAuth.py
+++ b/askomics/libaskomics/rdfdb/SparqlQueryAuth.py
@@ -24,9 +24,9 @@ class SparqlQueryAuth(SparqlQueryBuilder):
         return self.build_query_on_the_fly({
             'select': '?status',
             'query': "GRAPH <"+ self.get_param("askomics.users_graph") + "> {" +
-                      'BIND(EXISTS {:' + username + ' rdf:type foaf:Person} AS ?status)' +
-                      "}"
-        },True)
+                     'BIND(EXISTS {:' + username + ' rdf:type foaf:Person} AS ?status)' +
+                     "}"
+        }, True)
 
     def check_email_presence(self, email):
         """
@@ -37,7 +37,7 @@ class SparqlQueryAuth(SparqlQueryBuilder):
             'query': "GRAPH <"+ self.get_param("askomics.users_graph") + "> {" +
                      'BIND(EXISTS { ?uri foaf:mbox <mailto:' + email + '> } AS ?status)'+
                      "}"
-        },True)
+        }, True)
 
     def get_password_with_email(self, email):
         """
@@ -51,7 +51,7 @@ class SparqlQueryAuth(SparqlQueryBuilder):
                      '\t?URIusername :randomsalt ?salt .\n' +
                      '\t?URIusername :password ?shapw .\n'+
                      "}"
-        },True)
+        }, True)
 
     def get_password_with_username(self, username):
         """
@@ -65,7 +65,7 @@ class SparqlQueryAuth(SparqlQueryBuilder):
                      '\t?URIusername :randomsalt ?salt .\n' +
                      '\t?URIusername :password ?shapw .\n'+
                      "}"
-        },True)
+        }, True)
 
     def get_number_of_users(self):
         """
@@ -76,44 +76,47 @@ class SparqlQueryAuth(SparqlQueryBuilder):
             'query': "GRAPH <"+ self.get_param("askomics.users_graph") + "> {" +
                      '?s rdf:type foaf:Person .\n'
                      "}"
-        },True)
+        }, True)
 
-    def get_admin_status_by_username(self, username):
+    def get_admin_blocked_by_username(self, username):
         """
         get if a user is admin, by his username
         """
         return self.build_query_on_the_fly({
-            'select': '?admin',
+            'select': '?admin ?blocked',
             'query': "GRAPH <"+ self.get_param("askomics.users_graph") + "> {" +
                      '\t?URIusername rdf:type foaf:Person .\n' +
                      '\t?URIusername foaf:name \"' + username + '\" .\n' +
-                     '\t?URIusername :isadmin ?admin .'+
+                     '\t?URIusername :isadmin ?admin .\n'+
+                     '\t?URIusername :isblocked ?blocked .'
                      "}"
-        },True)
+        }, True)
 
-    def get_admin_status_by_email(self, email):
+    def get_admin_blocked_by_email(self, email):
         """
         get if a user is admin, by his email
         """
         return self.build_query_on_the_fly({
-            'select': '?admin',
+            'select': '?admin ?blocked',
             'query': "GRAPH <"+ self.get_param("askomics.users_graph") + "> {" +
                      '\n?URIusername rdf:type foaf:Person .\n' +
                      '\t?URIusername foaf:mbox <mailto:' + email + '> .\n' +
                      '\t?URIusername :isadmin ?admin .\n'+
+                     '\t?URIusername :isblocked ?blocked .'
                      "}"
-        },True)
+        }, True)
 
     def get_users_infos(self):
         """
         Get users infos
         """
         return self.build_query_on_the_fly({
-            'select': '?username ?email ?admin',
+            'select': '?username ?email ?admin ?blocked',
             'query': "GRAPH <"+ self.get_param("askomics.users_graph") + "> {" +
                      '\t?URIusername rdf:type foaf:Person .\n' +
                      '\t?URIusername foaf:name ?username .\n' +
                      '\t?URIusername foaf:mbox ?email .\n' +
                      '\t?URIusername :isadmin ?admin .\n'+
+                     '\t?URIusername :isblocked ?blocked .'
                      "}"
-        },True)
+        }, True)

--- a/askomics/libaskomics/rdfdb/SparqlQueryAuth.py
+++ b/askomics/libaskomics/rdfdb/SparqlQueryAuth.py
@@ -133,11 +133,3 @@ class SparqlQueryAuth(SparqlQueryBuilder):
                      '\t?URIusername :isadmin "true"^^xsd:boolean .\n'+
                      "}"
         }, True)
-
-    def change_blocked_status(self, username):
-        """
-        change the blocked status of a user
-        """
-        return self.build_query_on_the_fly({
-            'select': ''
-            })

--- a/askomics/libaskomics/rdfdb/SparqlQueryAuth.py
+++ b/askomics/libaskomics/rdfdb/SparqlQueryAuth.py
@@ -162,16 +162,17 @@ class SparqlQueryAuth(SparqlQueryBuilder):
             WHERE { :""" + username + """ foaf:mbox ?email }
             """)
 
-
-
-    # def update_admin_status(self, admin, username):
-    #     """
-    #     Change the admin status of a user!
-    #     """
-    #     return self.prepare_query(
-    #         """
-    #         WITH GRAPH <""" + self.get_param('askomics.users_graph') + """>
-    #         DELETE { :""" + username + """ :isadmin ?admin }
-    #         INSERT { :""" + username + """ :isadmin \"""" + admin + """\"^^xsd:boolean }
-    #         WHERE { :""" + username + """ :isadmin ?admin }
-    #         """)
+    def update_passwd(self, username, shapw, salt):
+        """
+        update the email of user
+        """
+        return self.prepare_query(
+            """
+            WITH GRAPH <""" + self.get_param('askomics.users_graph') + """>
+            DELETE { :""" + username + """ :password ?passwd .
+                     :""" + username + """ :randomsalt ?salt . }
+            INSERT { :""" + username + """ :password \"""" + shapw + """\" .
+                     :""" + username + """ :randomsalt \"""" + salt + """\" . }
+            WHERE { :""" + username + """ :password ?passwd .
+                    :""" + username + """ :randomsalt ?salt . }
+            """)

--- a/askomics/libaskomics/rdfdb/SparqlQueryAuth.py
+++ b/askomics/libaskomics/rdfdb/SparqlQueryAuth.py
@@ -133,3 +133,11 @@ class SparqlQueryAuth(SparqlQueryBuilder):
                      '\t?URIusername :isadmin "true"^^xsd:boolean .\n'+
                      "}"
         }, True)
+
+    def change_blocked_status(self, username):
+        """
+        change the blocked status of a user
+        """
+        return self.build_query_on_the_fly({
+            'select': ''
+            })

--- a/askomics/libaskomics/rdfdb/SparqlQueryAuth.py
+++ b/askomics/libaskomics/rdfdb/SparqlQueryAuth.py
@@ -106,9 +106,9 @@ class SparqlQueryAuth(SparqlQueryBuilder):
                      "}"
         }, True)
 
-    def get_users_infos(self):
+    def get_users_infos(self, me):
         """
-        Get users infos
+        Get users infos exept me
         """
         return self.build_query_on_the_fly({
             'select': '?username ?email ?admin ?blocked',
@@ -117,7 +117,8 @@ class SparqlQueryAuth(SparqlQueryBuilder):
                      '\t?URIusername foaf:name ?username .\n' +
                      '\t?URIusername foaf:mbox ?email .\n' +
                      '\t?URIusername :isadmin ?admin .\n'+
-                     '\t?URIusername :isblocked ?blocked .'
+                     '\t?URIusername :isblocked ?blocked .' +
+                     '\tFILTER NOT EXISTS { ?URIusername foaf:name "' + me + '" . }\n' +
                      "}"
         }, True)
 

--- a/askomics/libaskomics/rdfdb/SparqlQueryAuth.py
+++ b/askomics/libaskomics/rdfdb/SparqlQueryAuth.py
@@ -120,3 +120,16 @@ class SparqlQueryAuth(SparqlQueryBuilder):
                      '\t?URIusername :isblocked ?blocked .'
                      "}"
         }, True)
+
+    def get_admins_emails(self):
+        """
+        Get emails of all admins
+        """
+        return self.build_query_on_the_fly({
+            'select': '?email',
+            'query': "GRAPH <"+ self.get_param("askomics.users_graph") + "> {" +
+                     '\t?URIusername rdf:type foaf:Person .\n' +
+                     '\t?URIusername foaf:mbox ?email .\n' +
+                     '\t?URIusername :isadmin "true"^^xsd:boolean .\n'+
+                     "}"
+        }, True)

--- a/askomics/libaskomics/rdfdb/SparqlQueryBuilder.py
+++ b/askomics/libaskomics/rdfdb/SparqlQueryBuilder.py
@@ -97,7 +97,7 @@ class SparqlQueryBuilder(ParamManager):
 
     def update_admin_status(self, admin, username):
         """
-        hello!
+        Change the admin status of a user!
         """
         return self.prepare_query(
             """
@@ -105,6 +105,31 @@ class SparqlQueryBuilder(ParamManager):
             DELETE { :""" + username + """ :isadmin ?admin }
             INSERT { :""" + username + """ :isadmin \"""" + admin + """\"^^xsd:boolean }
             WHERE { :""" + username + """ :isadmin ?admin }
+            """)
+
+    def get_graph_of_user(self, username):
+        """
+        Get all subgraph of a user
+        """
+        return self.prepare_query(
+            """
+            SELECT ?g
+            WHERE {
+                ?g dc:creator \"""" + username + """\"
+            }
+            """)
+
+    def delete_user(self, username):
+        """
+        Delet all info of a user
+        """
+        return self.prepare_query(
+            """
+            DELETE WHERE {
+                GRAPH <"""+self.get_param('askomics.users_graph')+"""> {
+                    :""" + username +""" ?p ?o
+                }
+            }
             """)
 
     def prepare_query(self, template, replacement={}):

--- a/askomics/libaskomics/rdfdb/SparqlQueryBuilder.py
+++ b/askomics/libaskomics/rdfdb/SparqlQueryBuilder.py
@@ -19,6 +19,11 @@ class SparqlQueryBuilder(ParamManager):
         ParamManager.__init__(self, settings, session)
         self.log = logging.getLogger(__name__)
 
+    # def build_update_on_the_fly(self, replacment, adminRequest=False):
+    #     """
+    #     build an update query
+    #     """
+
     def build_query_on_the_fly(self, replacement,adminRequest=False):
         """
         Build a query from the private or public template
@@ -76,6 +81,30 @@ class SparqlQueryBuilder(ParamManager):
         return self.prepare_query(
             """
             DELETE WHERE { GRAPH <"""+self.session['graph']+"""> { <"""+graph+"""> ?p ?o }}
+            """)
+
+    def update_blocked_status(self, blocked, username):
+        """
+        hello!
+        """
+        return self.prepare_query(
+            """
+            WITH GRAPH <""" + self.get_param('askomics.users_graph') + """>
+            DELETE { :""" + username + """ :isblocked ?blocked }
+            INSERT { :""" + username + """ :isblocked \"""" + blocked + """\"^^xsd:boolean }
+            WHERE { :""" + username + """ :isblocked ?blocked }
+            """)
+
+    def update_admin_status(self, admin, username):
+        """
+        hello!
+        """
+        return self.prepare_query(
+            """
+            WITH GRAPH <""" + self.get_param('askomics.users_graph') + """>
+            DELETE { :""" + username + """ :isadmin ?admin }
+            INSERT { :""" + username + """ :isadmin \"""" + admin + """\"^^xsd:boolean }
+            WHERE { :""" + username + """ :isadmin ?admin }
             """)
 
     def prepare_query(self, template, replacement={}):

--- a/askomics/static/css/style.css
+++ b/askomics/static/css/style.css
@@ -172,3 +172,35 @@ div.uploadedQuery {
 .table-results {
     margin-bottom: 0px;
 }
+
+
+
+.icon {
+    display: inline-block;
+    margin: 20px;
+    font-size: 28px;
+}
+
+.spin {
+  -webkit-animation: spin 2s infinite linear;
+  animation: spin 2s infinite linear;
+}
+
+.pulse {
+    -webkit-animation: spin 1s infinite steps(8);
+    animation: spin 1s infinite steps(8);
+}
+
+@-webkit-keyframes spin {
+  0% { -webkit-transform: rotate(0deg); }
+  100% { -webkit-transform: rotate(359deg); }
+}
+@keyframes spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(359deg); }
+}
+
+@-webkit-keyframes spin-2 {
+  0% { -webkit-transform: rotate(0deg); }
+  100% { -webkit-transform: rotate(359deg); }
+}

--- a/askomics/static/js/AskomicsUser.js
+++ b/askomics/static/js/AskomicsUser.js
@@ -2,19 +2,21 @@
 
 class AskomicsUser {
 
-    constructor(username, admin) {
+    constructor(username, admin, blocked) {
         this.username = username ;
         this.admin = admin;
+        this.blocked = blocked;
     }
 
 
     logUser() {
-        displayNavbar(true, this.username, this.admin);
-        setTimeout(function() {
-            $('.container#content_login').hide();
-            $('.container#content_signup').hide();
-            $('.container#content_interrogation').show();
-        }, 1000);
+        // displayNavbar(true, this.username, this.admin, this.blocked);
+        location.reload();
+        // setTimeout(function() {
+        //     $('.container#content_login').hide();
+        //     $('.container#content_signup').hide();
+        //     $('.container#content_interrogation').show();
+        // }, 1000);
     }
 
     checkUser() {
@@ -28,7 +30,9 @@ class AskomicsUser {
             if (data.username) {
                 self.username = data.username;
                 self.admin = data.admin;
-                self.logUser();
+                self.blocked = data.blocked;
+                // self.logUser();
+                displayNavbar(true, self.username, self.admin, self.blocked);
             }else{
                 displayNavbar(false, '');
             }

--- a/askomics/static/js/AskomicsUser.js
+++ b/askomics/static/js/AskomicsUser.js
@@ -11,12 +11,13 @@ class AskomicsUser {
 
     logUser() {
         // displayNavbar(true, this.username, this.admin, this.blocked);
-        location.reload();
-        // setTimeout(function() {
-        //     $('.container#content_login').hide();
-        //     $('.container#content_signup').hide();
-        //     $('.container#content_interrogation').show();
-        // }, 1000);
+        // location.reload();
+        setTimeout(function() {
+            // $('.container#content_login').hide();
+            // $('.container#content_signup').hide();
+            // $('.container#content_interrogation').show();
+            location.reload();
+        }, 1000);
     }
 
     checkUser() {

--- a/askomics/static/js/MainAskomics.js
+++ b/askomics/static/js/MainAskomics.js
@@ -439,10 +439,51 @@ function loadUsers() {
     $('.unset_admin').click(function() {
       setAdmin(this.id, false);
     });
+    $('.del_user').click(function() {
+      delUser(this.id);
+    });
     hideModal();
   });
 
   new ShortcutsParametersView().updateShortcuts(true);
+}
+
+function delUser(username) {
+  console.log('-+-+-delUser ' + username + ' -+-+-');
+  // display confirmations buttons
+  $('.del_user#' + username).hide();
+  $('.div_confirm_del_user#' + username).removeClass('hidden').show();
+
+  //if no, redisplay the trash
+  $('.no_del_user#' + username).click(function() {
+    $('.del_user#' + username).show();
+    $('.div_confirm_del_user#' + username).hide();
+  });
+
+  //if yes, delete user and all this data and reload the list
+  $('.confirm_del_user#' + username).click(function(e) {
+    console.log('CONFIRM DELETE USER ' + username);
+    let service = new RestServiceJs('delete_user');
+    let data = {'username': username};
+    service.post(data, function(d) {
+      if (d == 'forbidden') {
+        showLoginForm();
+        return;
+      }
+      if (d == 'blocked') {
+        displayBlockedPage($('.username').attr('id'));
+        return;
+      }
+      // Reload the page
+      if (d == 'success') {
+        loadUsers();
+      }else{
+        alert(d)
+      }
+    });
+  });
+
+
 }
 
 function lockUser(username, lock) {
@@ -461,6 +502,8 @@ function lockUser(username, lock) {
     // Reload the page
     if (d == 'success') {
       loadUsers();
+    }else{
+      alert(d);
     }
   });
 }
@@ -482,6 +525,8 @@ function setAdmin(username, admin) {
     // Reload the page
     if (d == 'success') {
       loadUsers();
+    }else{
+      alert(d);
     }
   });
 }

--- a/askomics/static/js/MainAskomics.js
+++ b/askomics/static/js/MainAskomics.js
@@ -135,6 +135,10 @@ function loadNamedGraphs() {
     serviceNamedGraphs.getAll(function(namedGraphs) {
         if (namedGraphs == 'forbidden') {
           showLoginForm();
+          return;
+        }
+        if (namedGraphs == 'blocked') {
+          displayBlockedPage($('.username').attr('id'));
         }
         if (namedGraphs.length === 0) {
           disableDelButton();
@@ -198,6 +202,10 @@ function loadStatistics() {
       if (stats == 'forbidden') {
         showLoginForm();
         return;
+      }
+      if (stats == 'blocked') {
+          displayBlockedPage($('.username').attr('id'));
+          return;
       }
 
       $('#content_statistics').empty();
@@ -266,6 +274,11 @@ function deleteNamedGraph(graphs) {
         service.post(data, function(d){
           if (d == 'forbidden') {
             showLoginForm();
+            return;
+          }
+          if (d == 'blocked') {
+            displayBlockedPage($('.username').attr('id'));
+            return;
           }
         resetGraph();
         resetStats();
@@ -383,13 +396,29 @@ function setUploadForm(content,titleForm,route_overview,callback) {
   });
 }
 
-function displayNavbar(loged, username, admin) {
+function displayBlockedPage(username) {
+  console.log('-+-+- displayBlockedPage -+-+-');
+  $('#content_blocked').empty();
+  let source = $('#template-blocked').html();
+  let template = Handlebars.compile(source);
+
+  let context = {name: username};
+  let html = template(context);
+
+  hideModal();
+
+  $('.container').hide();
+  $('.container#navbar_content').show();
+  $('#content_blocked').append(html).show();
+}
+
+function displayNavbar(loged, username, admin, blocked) {
     console.log('-+-+- displayNavbar -+-+-');
     $("#navbar").empty();
     let source = $('#template-navbar').html();
     let template = Handlebars.compile(source);
 
-    let context = {name: 'AskOmics', loged: loged, username: username, admin: admin};
+    let context = {name: 'AskOmics', loged: loged, username: username, admin: admin, nonblocked: !blocked};
     let html = template(context);
 
     $("#navbar").append(html);
@@ -491,7 +520,7 @@ function displayNavbar(loged, username, admin) {
             $('#signup_success').show();
             // User is logged, show the special button
             console.log(data);
-            let user = new AskomicsUser(data.username);
+            let user = new AskomicsUser(data.username, data.admin, data.blocked);
             user.checkUser();
           }
       });

--- a/askomics/static/js/MainAskomics.js
+++ b/askomics/static/js/MainAskomics.js
@@ -448,7 +448,7 @@ function loadUsers() {
   new ShortcutsParametersView().updateShortcuts(true);
 }
 
-function delUser(username) {
+function delUser(username, reload=false) {
   console.log('-+-+-delUser ' + username + ' -+-+-');
   // display confirmations buttons
   $('.del_user#' + username).hide();
@@ -474,11 +474,14 @@ function delUser(username) {
         displayBlockedPage($('.username').attr('id'));
         return;
       }
+      if (reload) {
+        location.reload();
+      }
       // Reload the page
       if (d == 'success') {
         loadUsers();
       }else{
-        alert(d)
+        alert(d);
       }
     });
   });
@@ -528,6 +531,24 @@ function setAdmin(username, admin) {
     }else{
       alert(d);
     }
+  });
+}
+
+function userForm() {
+  console.log('-+-+- userForm -+-+-');
+
+  let service = new RestServiceJs('get_my_infos');
+  service.getAll(function(d) {
+    console.log(d);
+    let source = $('#template-user-managment').html();
+    let template = Handlebars.compile(source);
+    let context = {user: d};
+    let html = template(context);
+    $('#content_user_info').empty();
+    $('#content_user_info').append(html);
+    $('.del_user#' + d.username).click(function() {
+      delUser(d.username, true);
+    });
   });
 }
 
@@ -697,6 +718,12 @@ function displayNavbar(loged, username, admin, blocked) {
     $('#administration').click(function() {
       loadUsers();
     });
+
+    // admin page
+    $('#user_info').click(function() {
+      userForm();
+    });
+
 
 }
 

--- a/askomics/static/js/MainAskomics.js
+++ b/askomics/static/js/MainAskomics.js
@@ -67,7 +67,7 @@ function managePythonErrorEvent(data) {
     return false;
   }
   //otherwise empty last message !
-  $("#main_warning_display").empty();
+  $("#main_warning_display").empty().addClass('hidden');
   return true;
 }
 
@@ -554,23 +554,80 @@ function userForm() {
     $('.update_email#' + d.username).click(function() {
       updateMail(d.username);
     });
+    $('.update_passwd#' + d.username).click(function() {
+      updatePasswd(d.username);
+    });
+  });
+}
+
+function validateEmail(email) {
+  if (email === '') {
+    return false;
+  }
+  let regexp = /^([\w-\.]+@([\w-]+\.)+[\w-]{2,4})?$/;
+  return regexp.test(email);
+}
+
+function updatePasswd(username) {
+  console.log('-+-+-+ updatePasswd -+-+-+');
+  $('#tick_passwd').addClass('hidden');
+  let passwd = $('.new_passwd#' + username).val();
+  let passwd2 = $('.new_passwd2#' + username).val();
+  // check if the 2 passwd are identical
+  if (passwd != passwd2) {
+    managePythonErrorEvent({'error': 'Passwords are not identical'});
+    return;
+  }
+
+  // check if passwd is not empty
+  if (passwd === '') {
+    managePythonErrorEvent({'error': 'Password is empty'});
+    return;
+  }
+
+  //if passwd are identical, send it to the python server
+  let service = new RestServiceJs('update_passwd');
+  let data = {'passwd': passwd, 'passwd2': passwd2, 'username': username};
+  // display the spinning wheel
+  $('#spiner_passwd').removeClass('hidden');
+  $('#tick_passwd').addClass('hidden');
+  // Post the service
+  service.post(data, function(d) {
+    if (!managePythonErrorEvent(d)) {
+      $('#spiner_passwd').addClass('hidden');
+      return;
+    }
+    // It's ok, remove the spinning wheel and show the tick
+    $('#spiner_passwd').addClass('hidden');
+    $('#tick_passwd').removeClass('hidden');
   });
 }
 
 function updateMail(username) {
   console.log('-+-+- updateMail -+-+-');
-  console.log($('.new_email#' + username).val());
-  // Check if input is a valid mail
-
+  $('#tick_mail').addClass('hidden');
   let email = $('.new_email#' + username).val();
 
+  // check if email is valid (to avoid a useless request to the python server)
+  if (!validateEmail(email)) {
+    managePythonErrorEvent({'error': 'not a valid email'});
+    return;
+  }
 
-  // if yes, send it to the server
+  // if email is ok, send it to the server
   let service = new RestServiceJs('update_mail');
   let data = {'username': username, 'email': email};
+  $('#spiner_mail').removeClass('hidden');
+  $('#tick_mail').addClass('hidden');
+
   service.post(data, function(d) {
-    console.log(d);
-    alert(d);
+    if (! managePythonErrorEvent(d)) {
+      $('#spiner_mail').addClass('hidden');
+      return;
+    }
+    $('#spiner_mail').addClass('hidden');
+    $('#tick_mail').removeClass('hidden');
+    $('.new_email#' + username).val('').attr("placeholder", email);
   });
 }
 

--- a/askomics/static/js/MainAskomics.js
+++ b/askomics/static/js/MainAskomics.js
@@ -763,7 +763,7 @@ function displayNavbar(loged, username, admin, blocked) {
             // User is logged, show the special button
             console.log(data);
             let user = new AskomicsUser(data.username, data.admin, data.blocked);
-            user.checkUser();
+            user.logUser();
           }
       });
 

--- a/askomics/static/js/MainAskomics.js
+++ b/askomics/static/js/MainAskomics.js
@@ -573,6 +573,7 @@ function updatePasswd(username) {
   $('#tick_passwd').addClass('hidden');
   let passwd = $('.new_passwd#' + username).val();
   let passwd2 = $('.new_passwd2#' + username).val();
+  let current_passwd = $('.current_passwd#'+ username).val();
   // check if the 2 passwd are identical
   if (passwd != passwd2) {
     managePythonErrorEvent({'error': 'Passwords are not identical'});
@@ -580,14 +581,14 @@ function updatePasswd(username) {
   }
 
   // check if passwd is not empty
-  if (passwd === '') {
+  if (passwd === '' || current_passwd === '') {
     managePythonErrorEvent({'error': 'Password is empty'});
     return;
   }
 
   //if passwd are identical, send it to the python server
   let service = new RestServiceJs('update_passwd');
-  let data = {'passwd': passwd, 'passwd2': passwd2, 'username': username};
+  let data = {'current_passwd': current_passwd, 'passwd': passwd, 'passwd2': passwd2, 'username': username};
   // display the spinning wheel
   $('#spiner_passwd').removeClass('hidden');
   $('#tick_passwd').addClass('hidden');
@@ -600,6 +601,10 @@ function updatePasswd(username) {
     // It's ok, remove the spinning wheel and show the tick
     $('#spiner_passwd').addClass('hidden');
     $('#tick_passwd').removeClass('hidden');
+    // empty the fields
+    $('.new_passwd#' + username).val('');
+    $('.new_passwd2#' + username).val('');
+    $('.current_passwd#' + username).val('');
   });
 }
 

--- a/askomics/static/js/MainAskomics.js
+++ b/askomics/static/js/MainAskomics.js
@@ -549,9 +549,28 @@ function userForm() {
     $('.del_user#' + d.username).click(function() {
       delUser(d.username, true);
     });
+    $('.update_email#' + d.username).click(function() {
+      updateMail(d.username);
+    });
   });
 }
 
+function updateMail(username) {
+  console.log('-+-+- updateMail -+-+-');
+  console.log($('.new_email#' + username).val());
+  // Check if input is a valid mail
+
+  let email = $('.new_email#' + username).val();
+
+
+  // if yes, send it to the server
+  let service = new RestServiceJs('update_mail');
+  let data = {'username': username, 'email': email};
+  service.post(data, function(d) {
+    console.log(d);
+    alert(d);
+  });
+}
 
 function displayNavbar(loged, username, admin, blocked) {
     console.log('-+-+- displayNavbar -+-+-');

--- a/askomics/static/js/MainAskomics.js
+++ b/askomics/static/js/MainAskomics.js
@@ -412,6 +412,81 @@ function displayBlockedPage(username) {
   $('#content_blocked').append(html).show();
 }
 
+function loadUsers() {
+  console.log('-+-+- loadUsers -+-+-');
+
+  displayModal('Please wait', '', 'Close');
+
+  let service = new RestServiceJs('get_users_infos');
+  service.getAll(function(data) {
+    $("#Users_adm").empty();
+    let source = $('#template-admin-users').html();
+    let template = Handlebars.compile(source);
+
+    let context = {users: data.result};
+    let html = template(context);
+
+    $("#Users_adm").append(html);
+    $('.lock_user').click(function() {
+      lockUser(this.id, true);
+    });
+    $('.unlock_user').click(function() {
+      lockUser(this.id, false);
+    });
+    $('.set_admin').click(function() {
+      setAdmin(this.id, true);
+    });
+    $('.unset_admin').click(function() {
+      setAdmin(this.id, false);
+    });
+    hideModal();
+  });
+
+  new ShortcutsParametersView().updateShortcuts(true);
+}
+
+function lockUser(username, lock) {
+  console.log('-+-+- lockUser -+-+-');
+  let service = new RestServiceJs('lockUser');
+  let data = {'username': username, 'lock': lock};
+  service.post(data, function(d) {
+    if (d == 'forbidden') {
+      showLoginForm();
+      return;
+    }
+    if (d == 'blocked') {
+      displayBlockedPage($('.username').attr('id'));
+      return;
+    }
+    // Reload the page
+    if (d == 'success') {
+      loadUsers();
+    }
+  });
+}
+
+
+function setAdmin(username, admin) {
+  console.log('-+-+- setAdmin -+-+-');
+  let service = new RestServiceJs('setAdmin');
+  let data = {'username': username, 'admin': admin};
+  service.post(data, function(d) {
+    if (d == 'forbidden') {
+      showLoginForm();
+      return;
+    }
+    if (d == 'blocked') {
+      displayBlockedPage($('.username').attr('id'));
+      return;
+    }
+    // Reload the page
+    if (d == 'success') {
+      loadUsers();
+    }
+  });
+}
+
+
 function displayNavbar(loged, username, admin, blocked) {
     console.log('-+-+- displayNavbar -+-+-');
     $("#navbar").empty();
@@ -575,24 +650,7 @@ function displayNavbar(loged, username, admin, blocked) {
 
     // admin page
     $('#administration').click(function() {
-      console.log('-+-+- administration -+-+-');
-
-      displayModal('Please wait', '', 'Close');
-
-      let service = new RestServiceJs('get_users_infos');
-      service.getAll(function(data) {
-        $("#Users_adm").empty();
-        let source = $('#template-admin-users').html();
-        let template = Handlebars.compile(source);
-
-        let context = {users: data.result};
-        let html = template(context);
-
-        $("#Users_adm").append(html);
-        hideModal();
-      });
-
-      new ShortcutsParametersView().updateShortcuts(true);
+      loadUsers();
     });
 
 }

--- a/askomics/static/js/MainAskomics.js
+++ b/askomics/static/js/MainAskomics.js
@@ -419,7 +419,7 @@ function displayBlockedPage(username) {
 function loadUsers() {
   console.log('-+-+- loadUsers -+-+-');
 
-  displayModal('Please wait', '', 'Close');
+  // displayModal('Please wait', '', 'Close');
 
   let service = new RestServiceJs('get_users_infos');
   service.getAll(function(data) {
@@ -446,7 +446,7 @@ function loadUsers() {
     $('.del_user').click(function() {
       delUser(this.id);
     });
-    hideModal();
+    // hideModal();
   });
 
   new ShortcutsParametersView().updateShortcuts(true);
@@ -483,6 +483,11 @@ function delUser(username, reload=false, passwdconf=false) {
       manageErrorMessage({'error': 'Password is empty'});
       return;
     }
+
+    // Show the spinner
+    $('.spinner_del#' + username).removeClass('hidden');
+    $('.div_confirm_del_user#' + username).addClass('hidden');
+
     service.post(data, function(d) {
       if (!manageErrorMessage(d)) {
         return;
@@ -512,6 +517,15 @@ function lockUser(username, lock) {
   console.log('-+-+- lockUser -+-+-');
   let service = new RestServiceJs('lockUser');
   let data = {'username': username, 'lock': lock};
+
+    // Show the spinner
+  $('.spinner_lock#' + username).removeClass('hidden');
+  if (lock) {
+    $('.lock_user#' + username).addClass('hidden');
+  }else{
+    $('.unlock_user#' + username).addClass('hidden');
+  }
+
   service.post(data, function(d) {
     if (d == 'forbidden') {
       showLoginForm();
@@ -521,7 +535,7 @@ function lockUser(username, lock) {
       displayBlockedPage($('.username').attr('id'));
       return;
     }
-    // Reload the page
+    // Reload users
     if (d == 'success') {
       loadUsers();
     }else{
@@ -535,6 +549,15 @@ function setAdmin(username, admin) {
   console.log('-+-+- setAdmin -+-+-');
   let service = new RestServiceJs('setAdmin');
   let data = {'username': username, 'admin': admin};
+
+  // Show the spinner
+  $('.spinner_admin#' + username).removeClass('hidden');
+  if (admin) {
+    $('.set_admin#' + username).addClass('hidden');
+  }else{
+    $('.unset_admin#' + username).addClass('hidden');
+  }
+
   service.post(data, function(d) {
     if (d == 'forbidden') {
       showLoginForm();
@@ -544,7 +567,7 @@ function setAdmin(username, admin) {
       displayBlockedPage($('.username').attr('id'));
       return;
     }
-    // Reload the page
+    // Reload users
     if (d == 'success') {
       loadUsers();
     }else{

--- a/askomics/static/js/integration.js
+++ b/askomics/static/js/integration.js
@@ -253,6 +253,11 @@ function previewTtl(file_elem) {
     service.post(model, function(data) {
         if (data == 'forbidden') {
           showLoginForm();
+          return;
+        }
+        if (data == 'blocked') {
+          displayBlockedPage();
+          return;
         }
         file_elem.find(".preview_field").html(data);
         file_elem.find(".preview_field").show();
@@ -343,6 +348,11 @@ function checkExistingData(file_elem) {
     service.post(model, function(data) {
         if (data == 'forbidden') {
           showLoginForm();
+          return;
+        }
+        if (data == 'blocked') {
+          displayBlockedPage($('.username').attr('id'));
+          return;
         }
         file_elem.find('.column_header').each(function( index ) {
             if (data.headers_status[index-1] == 'present') {
@@ -410,6 +420,11 @@ function loadSourceFile(file_elem, pub) {
     service.post(model, function(data) {
         if (data == 'forbidden') {
           showLoginForm();
+          return;
+        }
+        if (data == 'blocked') {
+          displayBlockedPage($('.username').attr('id'));
+          return;
         }
         hideModal();
         var insert_status_elem = file_elem.find(".insert_status").first();
@@ -506,6 +521,11 @@ function loadSourceFileGff(filename, pub) {
     service.post(model, function(data) {
         if (data == 'forbidden') {
           showLoginForm();
+          return;
+        }
+        if (data == 'blocked') {
+          displayBlockedPage($('.username').attr('id'));
+          return;
         }
         // Show a success message isertion is OK
         let div_entity = $("#" + filename);
@@ -555,6 +575,11 @@ function loadSourceFileTtl(filename, pub) {
         console.log('---> ttl insert');
         if (data == 'forbidden') {
           showLoginForm();
+          return;
+        }
+        if (data == 'blocked') {
+          displayBlockedPage($('.username').attr('id'));
+          return;
         }
 
         let insert_status_elem = file_elem.find(".insert_status").first();

--- a/askomics/templates/index.pt
+++ b/askomics/templates/index.pt
@@ -194,6 +194,9 @@
             <hr/>
         </div>
 
+        <div id="content_blocked" class="container" hidden>
+        </div>
+
         <div id="content_administration" class="container" hidden>
             <hr/>
             <h3 class="header-div">Administration</h3>
@@ -305,6 +308,7 @@
                     <ul class="nav navbar-nav navbar-right">
                         <li id="interrogation" class="active"><a href="#" onclick="loadStartPoints();"><span class="glyphicon glyphicon-play"></span></a></li>
                         {{#if loged}}
+                        {{#if nonblocked}}
                         <li id="userdata" class="dropdown">
                             <li id="integration"><a href="#"><span class="glyphicon glyphicon-cloud-upload"></span></a></li>
                         </li>
@@ -316,6 +320,7 @@
                             </ul>
                           </li>
                         {{/if}}
+                        {{/if}}
                         <li id="about"><a href="#"><span class="glyphicon glyphicon-info-sign"></span></a></li>
                         <li id="help"><a href="#" onclick="AskomicsHelp.start();"><span class="glyphicon glyphicon-question-sign"></span></a></li>
                         {{#if loged}}
@@ -323,7 +328,7 @@
                         <li id="user_menu" class="dropdown">
                           <a class="dropdown-toggle" data-toggle="dropdown" href="#"><span class="glyphicon glyphicon-user"></span><span class="caret"></span></a>
                             <ul class="dropdown-menu">
-                                <li id="user_info"><a href="#"><span class="glyphicon glyphicon-cog"></span> Account managment ({{username}})</a></li>
+                                <li id="user_info"><a href="#"><span class="glyphicon glyphicon-cog"></span> Account managment (<i class='username' id='{{username}}'>{{username}}</i>)</a></li>
                             {{#if admin}}
                                 <li id="administration"><a href="#"><span class="glyphicon glyphicon-king"></span> Administration</a></li>
                             {{/if}}
@@ -573,6 +578,17 @@
                     <hr><br>
                 </div>
             </form>
+        </script>
+
+        <!-- template to display the blocked page -->
+        <script id="template-blocked" type="text/x-handlebars-template">
+          <div id="blocked_message">
+            <h4>Hello {{name}}!</h4>
+            <p>Your account is blocked, wait for an admin to unlock it.</p>
+            <p>In the meantime, you can play with the public data.</p>
+            <br />
+            <p>The AskoTeam.</p>
+          </div>
         </script>
 
 

--- a/askomics/templates/index.pt
+++ b/askomics/templates/index.pt
@@ -348,12 +348,14 @@
                 <th>Username</th>
                 <th>Email</th>
                 <th>Admin</th>
+                <th>Blocked</th>
             </tr>
             {{#each users}}
             <tr>
                 <td>{{this.username}}</td>
                 <td><a href="{{this.email}}">{{this.email}}</a></td>
                 <td>{{this.admin}}</td>
+                <td>{{this.blocked}}</td>
             </tr>
             {{/each}}
           </table>

--- a/askomics/templates/index.pt
+++ b/askomics/templates/index.pt
@@ -397,9 +397,9 @@
        <div class='col-md-6'>
          <div class="input-group">
           <span class="input-group-addon" id="basic-addon1">Email</span>
-          <input type="text" class="form-control" placeholder="{{user.email}}" aria-describedby="basic-addon1">
+          <input type="email" class="form-control new_email" id='{{user.username}}' placeholder="{{user.email}}" aria-describedby="basic-addon1">
           <span class="input-group-btn">
-            <button class="btn btn-default" type="button">Update</button>
+            <button class="btn btn-default update_email" id='{{user.username}}' type="button">Update</button>
           </span>
          </div>
         <br>

--- a/askomics/templates/index.pt
+++ b/askomics/templates/index.pt
@@ -377,7 +377,14 @@
                 <i style="color:green" class="fa fa-unlock lock_user" id="{{this.username}}"></i>
                 {{/if}}
                 </td>
-                <td><span style="color:red" class="glyphicon glyphicon-trash del_user" id={{this.username}}></span></td>
+                <td>
+                <span style="color:red" class="glyphicon glyphicon-trash del_user" id={{this.username}}></span>
+                {{!-- hidden confirm button --}}
+                <div class="btn-group div_confirm_del_user hidden" id='{{this.username}}' role="group">
+                  <button type="button" class="btn btn-danger btn-xs confirm_del_user" id='{{this.username}}'>Delete</button>
+                  <button type="button" class="btn btn-default btn-xs no_del_user" id='{{this.username}}'>No</button>
+                <div>
+                </td>
             </tr>
             {{/each}}
           </table>

--- a/askomics/templates/index.pt
+++ b/askomics/templates/index.pt
@@ -402,7 +402,7 @@
        <h4>Hello {{user.username}}</h4>
        <hr/ >
        {{#if user.blocked}}
-       <div class="alert alert-danger" role="alert">Your account is blocked, wait for an admin to unlock it</div>
+       <div class="alert alert-danger" role="alert">Your account is locked, wait for an admin to unlock it</div>
        {{/if}}
 
        <h4>Update your infos</h4>

--- a/askomics/templates/index.pt
+++ b/askomics/templates/index.pt
@@ -293,7 +293,7 @@
         </div><!-- /.modal -->
 
         <!-- Printing Warning message when error occurs -->
-        <div id="main_warning_display" class="insert_warning text-left alert hidden"></div>
+        <div id="main_warning_display" class="container insert_warning text-left alert hidden"></div>
 
         <!-- template for the navbar -->
         <script id='template-navbar' type="text/x-handlebars-template">
@@ -399,15 +399,28 @@
           <span class="input-group-addon" id="basic-addon1">Email</span>
           <input type="email" class="form-control new_email" id='{{user.username}}' placeholder="{{user.email}}" aria-describedby="basic-addon1">
           <span class="input-group-btn">
-            <button class="btn btn-default update_email" id='{{user.username}}' type="button">Update</button>
+            <button class="btn btn-default update_email" id='{{user.username}}' type="button">
+              <k>Update</k>
+              <i class="hidden fa fa-spinner pulse" id='spiner_mail'></i>
+              <i class="hidden fa fa-check text-success" id='tick_mail'></i>
+            </button>
           </span>
          </div>
         <br>
+
         <div class="input-group">
           <span class="input-group-addon" id="basic-addon1">Password</span>
-          <input type="text" class="form-control" placeholder="***************" aria-describedby="basic-addon1">
+          <input type="password" class="form-control new_passwd" id='{{user.username}}' placeholder="Enter a new password" aria-describedby="basic-addon1">
+         </div>
+         <div class="input-group">
+          <span class="input-group-addon" id="basic-addon1">Confirmation</span>
+          <input type="password" class="form-control new_passwd2" id='{{user.username}}' placeholder="Confirm your new password" aria-describedby="basic-addon1">
           <span class="input-group-btn">
-            <button class="btn btn-default" type="button">Update</button>
+            <button class="btn btn-default update_passwd" id='{{user.username}}' type="button">
+              Update
+              <i class="hidden fa fa-spinner pulse" id='spiner_passwd'></i>
+              <i class="hidden fa fa-check text-success" id='tick_passwd'></i>
+            </button>
           </span>
          </div>
       </div>

--- a/askomics/templates/index.pt
+++ b/askomics/templates/index.pt
@@ -189,9 +189,6 @@
         </div>
 
         <div id="content_user_info" class="container" hidden>
-            <hr/>
-            <h3 class="header-div">User page</h3>
-            <hr/>
         </div>
 
         <div id="content_blocked" class="container" hidden>
@@ -363,7 +360,7 @@
             <tr>
             {{/if}}
                 <td>{{this.username}}</td>
-                <td><a href="{{this.email}}">{{this.email}}</a></td>
+                <td><a href="mailto:{{this.email}}">{{this.email}}</a></td>
                 <td>
                 {{#if this.admin}}
                 <span style="color:orange" class="glyphicon glyphicon-king unset_admin" id={{this.username}}></span>
@@ -388,6 +385,43 @@
             </tr>
             {{/each}}
           </table>
+      </script>
+
+      <script id='template-user-managment' type="text/x-handlebars-template">
+       <h4>Hello {{user.username}}</h4>
+       {{#if user.blocked}}
+       <div class="alert alert-danger" role="alert">Your account is blocked, wait for an admin to unlock it</div>
+       {{/if}}
+
+       <h4>Update your infos</h4>
+       <div class='col-md-6'>
+         <div class="input-group">
+          <span class="input-group-addon" id="basic-addon1">Email</span>
+          <input type="text" class="form-control" placeholder="{{user.email}}" aria-describedby="basic-addon1">
+          <span class="input-group-btn">
+            <button class="btn btn-default" type="button">Update</button>
+          </span>
+         </div>
+        <br>
+        <div class="input-group">
+          <span class="input-group-addon" id="basic-addon1">Password</span>
+          <input type="text" class="form-control" placeholder="***************" aria-describedby="basic-addon1">
+          <span class="input-group-btn">
+            <button class="btn btn-default" type="button">Update</button>
+          </span>
+         </div>
+      </div>
+
+      <div class='col-md-12'>
+      <h4>Remove your account</h4>
+        <p>Remove your account and all your data</p>
+        <br>
+        <button type="button" class="btn btn-danger del_user" id='{{user.username}}'>Delete account</button>
+        <div class="btn-group div_confirm_del_user hidden" id='{{user.username}}' role="group">
+          <button type="button" class="btn btn-danger confirm_del_user" id='{{user.username}}'>Delete</button>
+          <button type="button" class="btn btn-default no_del_user" id='{{user.username}}'>No</button>
+        </div>
+      </div>
       </script>
 
      <script id='template-admin-shortcuts' type="text/x-handlebars-template">

--- a/askomics/templates/index.pt
+++ b/askomics/templates/index.pt
@@ -388,15 +388,19 @@
       </script>
 
       <script id='template-user-managment' type="text/x-handlebars-template">
+      <div class='col-md-6'>
        <h4>Hello {{user.username}}</h4>
+       <hr/ >
        {{#if user.blocked}}
        <div class="alert alert-danger" role="alert">Your account is blocked, wait for an admin to unlock it</div>
        {{/if}}
 
        <h4>Update your infos</h4>
-       <div class='col-md-6'>
-         <div class="input-group">
-          <span class="input-group-addon" id="basic-addon1">Email</span>
+       <hr/ >
+       <h5>Email</h5>
+
+        <div class="input-group">
+          <span class="input-group-addon" id="basic-addon1"><i class="fa fa-envelope" aria-hidden="true"></i></span>
           <input type="email" class="form-control new_email" id='{{user.username}}' placeholder="{{user.email}}" aria-describedby="basic-addon1">
           <span class="input-group-btn">
             <button class="btn btn-default update_email" id='{{user.username}}' type="button">
@@ -405,15 +409,20 @@
               <i class="hidden fa fa-check text-success" id='tick_mail'></i>
             </button>
           </span>
-         </div>
-        <br>
+        </div>
+
+        <h5>Password</h5>
 
         <div class="input-group">
-          <span class="input-group-addon" id="basic-addon1">Password</span>
+          <span class="input-group-addon" id="basic-addon1"><i class="fa fa-key" aria-hidden="true"></i></span>
+          <input type="password" class="form-control current_passwd" id='{{user.username}}' placeholder="Enter your current password" aria-describedby="basic-addon1">
+        </div>
+        <div class="input-group">
+          <span class="input-group-addon" id="basic-addon1"><i class="fa fa-key" aria-hidden="true"></i></span>
           <input type="password" class="form-control new_passwd" id='{{user.username}}' placeholder="Enter a new password" aria-describedby="basic-addon1">
-         </div>
-         <div class="input-group">
-          <span class="input-group-addon" id="basic-addon1">Confirmation</span>
+        </div>
+        <div class="input-group">
+          <span class="input-group-addon" id="basic-addon1"><i class="fa fa-key" aria-hidden="true"></i></span>
           <input type="password" class="form-control new_passwd2" id='{{user.username}}' placeholder="Confirm your new password" aria-describedby="basic-addon1">
           <span class="input-group-btn">
             <button class="btn btn-default update_passwd" id='{{user.username}}' type="button">
@@ -422,11 +431,11 @@
               <i class="hidden fa fa-check text-success" id='tick_passwd'></i>
             </button>
           </span>
-         </div>
-      </div>
+        </div>
 
-      <div class='col-md-12'>
+      <hr/ >
       <h4>Remove your account</h4>
+      <hr/ >
         <p>Remove your account and all your data</p>
         <br>
         <button type="button" class="btn btn-danger del_user" id='{{user.username}}'>Delete account</button>

--- a/askomics/templates/index.pt
+++ b/askomics/templates/index.pt
@@ -354,13 +354,30 @@
                 <th>Email</th>
                 <th>Admin</th>
                 <th>Blocked</th>
+                <th>Delete account</th>
             </tr>
             {{#each users}}
+            {{#if this.blocked}}
+            <tr class="danger">
+            {{else}}
             <tr>
+            {{/if}}
                 <td>{{this.username}}</td>
                 <td><a href="{{this.email}}">{{this.email}}</a></td>
-                <td>{{this.admin}}</td>
-                <td>{{this.blocked}}</td>
+                <td>
+                {{#if this.admin}}
+                <span style="color:orange" class="glyphicon glyphicon-king unset_admin" id={{this.username}}></span>
+                {{else}}
+                <span style="color:grey" class="glyphicon glyphicon-pawn set_admin" id={{this.username}}></span>
+                {{/if}}
+                </td>
+                <td>{{#if this.blocked}}
+                <i style="color:red" class="fa fa-lock unlock_user" id="{{this.username}}"></i>
+                {{else}}
+                <i style="color:green" class="fa fa-unlock lock_user" id="{{this.username}}"></i>
+                {{/if}}
+                </td>
+                <td><span style="color:red" class="glyphicon glyphicon-trash del_user" id={{this.username}}></span></td>
             </tr>
             {{/each}}
           </table>

--- a/askomics/templates/index.pt
+++ b/askomics/templates/index.pt
@@ -333,7 +333,14 @@
                         {{#if loged}}
 
                         <li id="user_menu" class="dropdown">
-                          <a class="dropdown-toggle" data-toggle="dropdown" href="#"><span class="glyphicon glyphicon-user"></span><span class="caret"></span></a>
+                          <a class="dropdown-toggle" data-toggle="dropdown" href="#">
+                          {{#if admin}}
+                            <span class="glyphicon glyphicon-king"></span>
+                          {{else}}
+                            <span class="glyphicon glyphicon-user"></span>
+                          {{/if}}
+                            <span class="caret"></span>
+                          </a>
                             <ul class="dropdown-menu">
                                 <li id="user_info"><a href="#"><span class="glyphicon glyphicon-cog"></span> Account managment (<i class='username' id='{{username}}'>{{username}}</i>)</a></li>
                             {{#if admin}}
@@ -377,12 +384,14 @@
                 {{else}}
                 <span style="color:grey" class="glyphicon glyphicon-pawn set_admin" id={{this.username}}></span>
                 {{/if}}
+                <i class="hidden fa fa-spinner pulse spinner_admin" id='{{this.username}}'></i>
                 </td>
                 <td>{{#if this.blocked}}
                 <i style="color:red" class="fa fa-lock unlock_user" id="{{this.username}}"></i>
                 {{else}}
                 <i style="color:green" class="fa fa-unlock lock_user" id="{{this.username}}"></i>
                 {{/if}}
+                <i class="hidden fa fa-spinner pulse spinner_lock" id='{{this.username}}'></i>
                 </td>
                 <td>
                 <span style="color:red" class="glyphicon glyphicon-trash del_user" id={{this.username}}></span>
@@ -390,7 +399,8 @@
                 <div class="btn-group div_confirm_del_user hidden" id='{{this.username}}' role="group">
                   <button type="button" class="btn btn-danger btn-xs confirm_del_user" id='{{this.username}}'>Delete</button>
                   <button type="button" class="btn btn-default btn-xs no_del_user" id='{{this.username}}'>No</button>
-                <div>
+                </div>
+                <i class="hidden fa fa-spinner pulse spinner_del" id='{{this.username}}'></i>
                 </td>
             </tr>
             {{/each}}

--- a/askomics/templates/index.pt
+++ b/askomics/templates/index.pt
@@ -72,8 +72,8 @@
                 <div class="form-group">
                     <label for="startpoint" class="col-md-offset-2">Please select a start point for your query :</label>
                     <select id='startpoints' size='8' class="form-control col-md-offset-2"></select>
-                    <div class="col-md-offset-2">Public data are <em class='text-warning'>yellow</em> and private data are <strong class='text-primary'>blue</strong></div>
-                    <div class="col-md-offset-2">Public-private data are <strong class='text-warning'><em>yellow</em></strong></div>
+                    <div class="col-md-offset-2">Shared entities are <em class='text-warning'>yellow</em> and personal entities are <strong class='text-primary'>blue</strong></div>
+                    <div class="col-md-offset-2">Mixed entities are <strong class='text-warning'><em>yellow</em></strong></div>
                 </div>
                 <button  id="starter" class="btn btn-default col-md-offset-2" onclick="startVisualisation();">Start</button>
                 <br><br><br>
@@ -360,7 +360,7 @@
                 <th>Username</th>
                 <th>Email</th>
                 <th>Admin</th>
-                <th>Blocked</th>
+                <th>Locked</th>
                 <th>Delete account</th>
             </tr>
             {{#each users}}

--- a/askomics/templates/index.pt
+++ b/askomics/templates/index.pt
@@ -292,8 +292,18 @@
           </div><!-- /.modal-dialog -->
         </div><!-- /.modal -->
 
-        <!-- Printing Warning message when error occurs -->
-        <div id="main_warning_display" class="container insert_warning text-left alert hidden"></div>
+        <script id='template-error-message' type="text/x-handlebars-template">
+        <div id='error_div'>
+        <br><br>
+        <div class="container alert alert-dismissible alert-danger">
+          <button type="button" class="close" data-dismiss="alert">&times;</button>
+          <p id='error_message'></p>
+          <i class="fa fa-exclamation-circle" aria-hidden="true"></i>
+          <strong>Error: </strong>
+          {{message}}
+        </div>
+        </div>
+        </script>
 
         <!-- template for the navbar -->
         <script id='template-navbar' type="text/x-handlebars-template">
@@ -437,11 +447,20 @@
       <h4>Remove your account</h4>
       <hr/ >
         <p>Remove your account and all your data</p>
+        <p class='text-danger'>
+          <i class="fa fa-exclamation-circle" aria-hidden="true"></i>
+          This action can't be undone!
+        </p>
         <br>
-        <button type="button" class="btn btn-danger del_user" id='{{user.username}}'>Delete account</button>
+        <button type="button" class="btn btn-danger del_user" id='{{user.username}}'><i class="fa fa-trash" aria-hidden="true"></i> Delete account</button>
         <div class="btn-group div_confirm_del_user hidden" id='{{user.username}}' role="group">
           <button type="button" class="btn btn-danger confirm_del_user" id='{{user.username}}'>Delete</button>
           <button type="button" class="btn btn-default no_del_user" id='{{user.username}}'>No</button>
+        </div>
+        <br>
+        <div class="hidden passwd2del-group input-group" id="basic-addon1">
+          <span class="input-group-addon"><i class="fa fa-key" aria-hidden="true"></i></span>
+          <input type="password" class="form-control passwd_del" id='{{user.username}}' placeholder="Enter your password" aria-describedby="basic-addon1">
         </div>
       </div>
       </script>

--- a/configs/development.virtuoso.ini
+++ b/configs/development.virtuoso.ini
@@ -58,6 +58,9 @@ askomics.proxy_https = https://www.example.com:3129/
 askomics.proxy_username = username
 askomics.proxy_password = password
 
+# SMTP Server
+smtp.host=Sphinx
+
 ###
 # wsgi server configuration
 ###


### PR DESCRIPTION
### Administration

- [x] When a user create an account, he can't load files (locked account). If a smtp server is defined in the config file, a mail is sent to all admins.

- [x] Admins can lock/unlock users by clicking the padlock
- [x] Admins can set/unset other users admin by clicking to the chess piece (grey pawn for regular user, yellow king for admin)
- [x] Admins can delete users by clicking to the trash. This action delete the user and all his data

![screenshot_20170203_120107](https://cloud.githubusercontent.com/assets/18330770/22588996/7e30a274-ea08-11e6-8b33-43a727d8be40.png)

### Account managment

- [x] User can update his email and password
- [x] User can delete his acount (user+all data)

![screenshot_20170203_120625](https://cloud.githubusercontent.com/assets/18330770/22589162/357e9b52-ea09-11e6-8ffa-1927d4c434d6.png)

### Other improvment

- [x] Use handlebars template to display the error message
- [x] Change public/private data into shared/personal entities
 