### PR TITLE
readme: fix table by removing uneeded column

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ AskOmics also uses the following bundled libraries:
 #### Browser compatibility
 
 | Chrome | Firefox | Internet Explorer | Opera | Safari |
-|---|---|---|---|---|---|
+|---|---|---|---|---|
 | 38+  | 13+  | Not supported  | 25+  |  7.1+ |
 
 ### Install Askomics


### PR DESCRIPTION
The table about browsers support is not rendered correctly.
Problem is a supplementary column in second line of the table.
This PR deletes it.