### PR TITLE
Fix delete uploaded file

### DIFF
--- a/askomics/static/js/app/core/IHMLocal.js
+++ b/askomics/static/js/app/core/IHMLocal.js
@@ -550,6 +550,7 @@ class IHMLocal {
 
         formHtmlforUploadFiles.html = formHtmlforUploadFiles.html.replace("___TITLE_UPLOAD___",titleForm);
         formHtmlforUploadFiles.html = formHtmlforUploadFiles.html.replace("___SIZE_UPLOAD____",(sizeFileMax/(1000*1000))+" Mo");
+        formHtmlforUploadFiles.html = formHtmlforUploadFiles.html.replace('___URL___', $(location).attr('href'));
 
         $(content).html(formHtmlforUploadFiles.html);
         /*

--- a/askomics/templates/upload.pt
+++ b/askomics/templates/upload.pt
@@ -119,7 +119,7 @@
         </td>
         <td>
             {% if (file.delete_url) { %}
-                <button class="btn btn-danger delete" data-type="{%=file.delete_type%}" data-url="{%=file.delete_url%}">
+                <button class="btn btn-danger delete" data-type="{%=file.delete_type%}" data-url="___URL___up/file/{%=file.delete_url%}">
                     <i class="glyphicon glyphicon-trash"></i>
                     <span>Delete</span>
                 </button>

--- a/askomics/upload.py
+++ b/askomics/upload.py
@@ -73,7 +73,8 @@ class FileUpload(object):
             info['name'] = name
             info['size'] = os.path.getsize(filename)
             info['delete_type'] = self.delete_method
-            info['delete_url'] = self.request.route_url('upload', sep='', name='') + '/' + name
+            info['delete_url'] = name
+            # info['delete_url'] = self.request.route_url('upload', sep='', name='') + '/' + name
             if self.delete_method != 'DELETE':
                 info['delete_url'] += '&_method=DELETE'
             return info
@@ -145,7 +146,7 @@ class FileUpload(object):
                 os.remove(self.filepath(result['name'])+"_tmp")
                 result['size'] = self.get_file_size(open(self.filepath(result['name']),"rb"))
                 result['delete_type'] = self.delete_method
-                result['delete_url'] = self.request.route_url('upload', sep='', name='') + '/' + result['name']
+                result['delete_url'] = result['name']
                 if self.delete_method != 'DELETE':
                     result['delete_url'] += '&_method=DELETE'
             results.append(result)


### PR DESCRIPTION
When askomics is running through a reverse proxy, url doesn't match the pyramid route, so we couldn't delete uploaded files.

This PR fix it by replacing the route with the current url (get with `$($(location).attr('href'))`)