### PR TITLE
Fix #141

### DIFF
--- a/askomics/static/src/js/core/AskomicsGraphBuilder.js
+++ b/askomics/static/src/js/core/AskomicsGraphBuilder.js
@@ -1,11 +1,4 @@
 /*jshint esversion: 6 */
-const classesMapping = {
-  'AskomicsPositionableNode': AskomicsPositionableNode,
-  'AskomicsNode': AskomicsNode,
-  'GraphLink': GraphLink,
-  'AskomicsLink': AskomicsLink,
-  'AskomicsPositionableLink': AskomicsPositionableLink
-};
 
 /* constructeur de AskomicsGraphBuilder */
   class AskomicsGraphBuilder {
@@ -96,7 +89,12 @@ const classesMapping = {
         for (let i=0;i<nodes.length;i++) {
           let className = nodes[i][0];
           let jsonObj = nodes[i][1];
-          let n = new classesMapping[className]({uri:"undefined"});
+          let n;
+          if (jsonObj._positionable) {
+            n = new AskomicsPositionableNode({uri:"undefined"});
+          }else{
+            n = new AskomicsNode({uri:"undefined"});
+          }
           n.setjson(jsonObj);
           this.nodes().push(n);
         }
@@ -105,7 +103,12 @@ const classesMapping = {
         for (let i=0;i<links.length;i++) {
           let className = links[i][0];
           let jsonObj = links[i][1];
-          let l = new classesMapping[className]({uri:"undefined"});
+          let l;
+          if (jsonObj._positionable) {
+            l = new AskomicsPositionableLink({uri:"undefined"});
+          }else{
+            l = new AskomicsLink({uri:"undefined"});
+          }
           l.setjson(jsonObj,this);
           this.links().push(l);
         }

--- a/askomics/static/src/js/objects/link/AskomicsLink.js
+++ b/askomics/static/src/js/objects/link/AskomicsLink.js
@@ -5,6 +5,7 @@ class AskomicsLink extends GraphLink {
 
   constructor(link,sourceN,targetN) {
     super(link,sourceN,targetN);
+    this._positionable = false;
     this._transitive = false ;
     this._negative   = false ;
     this._subclassof = false ;

--- a/askomics/static/src/js/objects/link/AskomicsPositionableLink.js
+++ b/askomics/static/src/js/objects/link/AskomicsPositionableLink.js
@@ -4,7 +4,7 @@ class AskomicsPositionableLink extends AskomicsLink {
 
   constructor(link,sourceN,targetN) {
     super(link,sourceN,targetN);
-
+    this._positionable = true;
     this.type         = 'included' ;
     this.label        = 'included in';
     this.same_tax     =  false;

--- a/askomics/static/src/js/objects/node/AskomicsNode.js
+++ b/askomics/static/src/js/objects/node/AskomicsNode.js
@@ -5,6 +5,7 @@ class AskomicsNode extends GraphNode {
   constructor(node,x,y) {
     super(node,x,y);
 
+    this._positionable = false;
     this._attributes = {} ;
     this._categories = {} ;
     this._filters    = {} ; /* filters of attributes key:sparqlid*/

--- a/askomics/static/src/js/objects/node/AskomicsPositionableNode.js
+++ b/askomics/static/src/js/objects/node/AskomicsPositionableNode.js
@@ -4,6 +4,7 @@ class AskomicsPositionableNode extends AskomicsNode {
 
   constructor(node,x,y) {
     super(node,x,y);
+    this._positionable = true;
   }
 
   setjson(obj) {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -16,6 +16,7 @@ var uglifycss = require('gulp-uglifycss');
 var handlebars = require('gulp-handlebars');
 var wrap = require('gulp-wrap');
 var declare = require('gulp-declare');
+var pump = require('pump');
 //var remapIstanbul = require('remap-istanbul/lib/gulpRemapIstanbul');
 
 //console.log(require('istanbul').Report.getReportList());
@@ -73,41 +74,44 @@ gulp.task('default', ['javascript', 'css', 'templates'], function () {
 });
 
 // Concat all js files, uglyfy if --prod
-gulp.task('javascript', function() {
-    return gulp.src(askomicsSourceFiles)
-               .pipe(jshint())
-               .pipe(jshint.reporter('default'))
-               .pipe(babel({
-                   presets: ['es2015']
-                }))
-               .pipe(concat('askomics.js'))
-               .pipe(prod ? uglify() : util.noop())
-               .pipe(gulp.dest('askomics/static/dist/'));
+gulp.task('javascript', function(cb) {
+    pump([
+        gulp.src(askomicsSourceFiles),
+        jshint(),
+        jshint.reporter('default'),
+        babel({presets: ['es2015']}),
+        concat('askomics.js'),
+        prod ? uglify() : util.noop(),
+        gulp.dest('askomics/static/dist/')
+    ], cb);
 });
 
 // Concat all css files, uglyfy if --prod
-gulp.task('css', function() {
-    return gulp.src(askomicsCssFiles)
-               .pipe(concat('askomics.css'))
-               .pipe(prod ? uglifycss() : util.noop())
-               .pipe(gulp.dest('askomics/static/dist/'));
+gulp.task('css', function(cb) {
+    pump([
+        gulp.src(askomicsCssFiles),
+        prod ? uglifycss() : util.noop(),
+        gulp.dest('askomics/static/dist/')
+    ], cb);
 });
 
 // Concat all handlebars files, uglyfy if --prod
-gulp.task('templates', function() {
-    return gulp.src(askomicsTemplateFiles)
-               .pipe(handlebars({
-                   handlebars: require('handlebars')
-               }))
-               .pipe(wrap('Handlebars.template(<%= contents %>)'))
-               .pipe(declare({
-                   namespace: 'AskOmics.templates',
-                   noRedeclare: true,
-               }))
-               .pipe(concat('templates.js'))
-               .pipe(prod ? uglify() : util.noop())
-               .pipe(gulp.dest('askomics/static/dist/'));
-    });
+gulp.task('templates', function(cb) {
+    pump([
+        gulp.src(askomicsTemplateFiles),
+        handlebars({
+            handlebars: require('handlebars')
+        }),
+        wrap('Handlebars.template(<%= contents %>)'),
+        declare({
+            namespace: 'AskOmics.templates',
+            noRedeclare: true
+        }),
+        concat('templates.js'),
+        prod ? uglify() : util.noop(),
+        gulp.dest('askomics/static/dist/')
+    ], cb)
+});
 
 
 

--- a/startAskomics.sh
+++ b/startAskomics.sh
@@ -150,7 +150,6 @@ askojs="$dir_askomics/askomics/static/dist/askomics.js"
 if [[ $run == false || ! -f $askojs ]]; then
     echo "deploying javascript ..."
     gulp $gulpmode &
-    sleep 8
 fi
 
 # Run Askomics --------------------------------------------


### PR DESCRIPTION
- Add a `_positionable` var in link and node objects and check it to build the object. Fix issue #141.

- Use pump in gulpfile to help properly handle error conditions with Node streams ([why?](https://github.com/terinjokes/gulp-uglify/blob/master/docs/why-use-pump/README.md#why-use-pump))

