### PR TITLE
remove useless npm packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,10 +16,12 @@ dist/
 
 # Javascript & utils
 node_modules
-askomics/test/client/js/istanbul
-.coverage-js
-output_test.log
 askomics/test/client/index_tpl.html
+.coverage-js
+askomics/test/client/js/istanbul
+askomics/test/client/js/src/
+coverage
+output_test.log
 
 # Editors & tooling
 *.orig

--- a/askomics/libaskomics/SourceFileConvertor.py
+++ b/askomics/libaskomics/SourceFileConvertor.py
@@ -62,12 +62,12 @@ class SourceFileConvertor(ParamManager):
         extension = os.path.splitext(filepath)[1]
         if extension.lower() in ('.gff', '.gff2', '.gff3'):
             return 'gff'
-        elif extension.lower() in ('.ttl', '.rdf'):
+        if extension.lower() in ('.ttl', '.rdf'):
             return 'ttl'
-        elif extension.lower() in ('.bed', ):
+        if extension.lower() in ('.bed', ):
             return 'bed'
-        else:
-            return 'csv'
+
+        return 'csv'
 
     def get_source_file(self, name, forced_type=None, uri=None):
         """

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2,26 +2,14 @@ var gulp = require('gulp');
 var util = require('gulp-util');
 var jshint = require('gulp-jshint');
 var concat = require('gulp-concat');
-//version 1.7.1 with bug
-//var sourcemaps = require('gulp-sourcemaps');
 var babel = require('gulp-babel');
-//var mocha = require('gulp-mocha');
-var inject = require('gulp-inject');
-//var rename = require('gulp-rename');
-var istanbul = require('gulp-istanbul');
-var mochaPhantomJS = require('gulp-mocha-phantomjs');
-var istanbulReport = require('gulp-istanbul-report');
 var uglify = require('gulp-uglify');
 var uglifycss = require('gulp-uglifycss');
 var handlebars = require('gulp-handlebars');
 var wrap = require('gulp-wrap');
 var declare = require('gulp-declare');
 var pump = require('pump');
-//var remapIstanbul = require('remap-istanbul/lib/gulpRemapIstanbul');
 
-//console.log(require('istanbul').Report.getReportList());
-
-// var askomicsSourceFiles = ['askomics/static/js/app/**/*.js','!askomics/static/js/app/third-party/**/*.js'];
 var askomicsSourceFiles = [
         'askomics/static/src/js/help/AskomicsHelp.js',
         'askomics/static/src/js/services/AskomicsRestManagement.js',
@@ -138,6 +126,7 @@ var mochaPhantomOpts = {
 
 //https://github.com/willembult/gulp-istanbul-report
 gulp.task('pre-test', function () {
+  var istanbul = require('gulp-istanbul');
   return gulp.src(askomicsSourceFiles, {base: "askomics/static/js"})
   //  .pipe(sourcemaps.init())
     .pipe(babel({presets: ['es2015']}))
@@ -178,6 +167,9 @@ askomicsInstrumentedSourceFiles.forEach(function(element, index) {
 
 
 gulp.task('test', ['default','pre-test','pre-test-srctest'],function () {
+    var inject = require('gulp-inject');
+    var mochaPhantomJS = require('gulp-mocha-phantomjs');
+    var istanbulReport = require('gulp-istanbul-report');
     return gulp
     .src('askomics/test/client/index_tpl.html')
     .pipe(inject(gulp.src(testFrameworkFiles, {read: false}) , {relative: true, name: 'testFramework'}))

--- a/package.json
+++ b/package.json
@@ -1,60 +1,42 @@
 {
-  "name": "askomics",
-  "version": "2.0.0-RC1",
-  "devDependencies": {
-    "babel-preset-es2015": "^6.9.0",
-    "chai": "^3.5.0",
-    "gulp": "^3.9.1",
-    "gulp-babel": "^6.1.2",
-    "gulp-concat": "^2.6.1",
-    "gulp-declare": "^0.3.0",
-    "gulp-depend": "^1.0.0",
-    "gulp-handlebars": "^4.0.0",
-    "gulp-inject": "^4.1.0",
-    "gulp-istanbul": "^1.0.0",
-    "gulp-istanbul-report": "0.0.1",
-    "gulp-jquery": "^1.1.2",
-    "gulp-jshint": "^2.0.1",
-    "gulp-mocha": "^2.2.0",
-    "gulp-mocha-phantomjs": "^0.11.0",
-    "gulp-rename": "^1.2.2",
-    "gulp-sourcemaps": "^1.6.0",
-    "pump": "^1.0.2",
-    "gulp-uglify": "^1.5.4",
-    "gulp-uglifycss": "^1.0.8",
-    "gulp-util": "^3.0.7",
-    "gulp-wrap": "^0.13.0",
-    "handlebars": "^4.0.8",
-    "istanbul": "^0.4.4",
-    "jquery": "^3.2.1",
-    "jshint": "^2.9.2",
-    "mocha": "^2.5.3",
-    "mocha-phantomjs-istanbul": "0.0.2",
-    "remap-istanbul": "^0.6.4",
-    "runtime": "^0.14.1",
-    "should": "^10.0.0"
-  },
+  "name": "AskOmics",
+  "version": "2.0.0",
+  "description": "Visual SPARQL query builder",
   "main": "gulpfile.js",
-  "directories": {
-    "doc": "doc"
-  },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "gulp test"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/askomics/askomics/"
+    "url": "https://github.com/askomics/askomics.git"
   },
-  "keywords": [
-    "semantic",
-    "web",
-    "ontology"
-  ],
+  "keywords": ["Sementic Web", "Ontology"],
   "author": "INRA",
-  "license": "GPL-3.0",
-  "dependencies": {
-    "intro.js": "^2.3.0",
-    "time-require": "^0.1.2"
+  "license": "AGPL",
+  "bugs": {
+    "url": "https://github.com/askomics/askomics/issues"
   },
-  "description": "[![Build Status](https://travis-ci.org/askomics/askomics.svg?branch=master)](https://travis-ci.org/askomics/askomics) [![Coverage Status](https://coveralls.io/repos/github/askomics/askomics/badge.svg?branch=master)](https://coveralls.io/github/askomics/askomics?branch=master)"
+  "homepage": "https://askomics.github.io",
+  "dependencies": {
+    "jshint": "^2.9.2",
+    "gulp": "^3.9.1",
+    "gulp-util": "^3.0.7",
+    "gulp-jshint": "^2.0.1",
+    "gulp-babel": "^6.1.2",
+    "gulp-concat": "^2.6.1",
+    "gulp-uglify": "^1.5.4",
+    "gulp-uglifycss": "^1.0.8",
+    "gulp-declare": "^0.3.0",
+    "gulp-handlebars": "^4.0.0",
+    "gulp-wrap": "^0.13.0",
+    "pump": "^1.0.2",
+    "handlebars": "^4.0.8",
+    "babel-preset-es2015": "^6.9.0"
+  },
+  "devDependencies": {
+    "gulp-inject": "^4.1.0",
+    "gulp-istanbul": "^1.0.0",
+    "gulp-istanbul-report": "0.0.1",
+    "gulp-mocha-phantomjs": "^0.11.0"
+  }
 }


### PR DESCRIPTION
Cleaning of the package.json and gulpfile

In `package.json`, dependencies are npm package to run askomics, devDependencies are needed for tests.

During installation, use `npm install --production` (install only dependencies) or `npm install` (dependencies and Devdependencies), depending of what you need.