### PR TITLE
Convert Environment variables to INI properties

### DIFF
--- a/askomics/libaskomics/ParamManager.py
+++ b/askomics/libaskomics/ParamManager.py
@@ -35,11 +35,11 @@ class ParamManager(object):
         }
 
         self.userfilesdir = 'askomics/static/results/'
-        if not 'user.files.dir' in self.settings:
-            self.log.warning(" ******* 'user.files.dir' is not defined ! ********* "
+        if not 'askomics.files_dir' in self.settings:
+            self.log.warning(" ******* 'askomics.files_dir' is not defined ! ********* "
                              "\n Csv are saved in "+self.userfilesdir)
         else:
-            self.userfilesdir = self.settings['user.files.dir']+"/"
+            self.userfilesdir = self.settings['askomics.files_dir']+"/"
 
         self.ASKOMICS_html_template = 'askomics/templates/integration.pt'
 
@@ -221,24 +221,24 @@ class ParamManager(object):
         self.log.debug(" == Security.py:send_mails == ")
         # Don't send mail if the smtp server is not in
         # the config file
-        if not self.get_param('smtp.host'):
+        if not self.get_param('askomics.smtp_host'):
             return
-        if not self.get_param('smtp.port'):
+        if not self.get_param('askomics.smtp_port'):
             return
-        if not self.get_param('smtp.login'):
+        if not self.get_param('askomics.smtp_login'):
             return
-        if not self.get_param('smtp.password'):
+        if not self.get_param('askomics.smtp_password'):
             return
         starttls = False
-        if self.get_param('smtp.starttls'):
-            starttls = self.get_param('smtp.starttls').lower() == 'yes' or \
-                       self.get_param('smtp.starttls').lower() == 'ok' or \
-                       self.get_param('smtp.starttls').lower() == 'true'
+        if self.get_param('askomics.smtp_starttls'):
+            starttls = self.get_param('askomics.smtp_starttls').lower() == 'yes' or \
+                       self.get_param('askomics.smtp_starttls').lower() == 'ok' or \
+                       self.get_param('askomics.smtp_starttls').lower() == 'true'
 
-        host = self.get_param('smtp.host')
-        port = self.get_param('smtp.port')
-        login = self.get_param('smtp.login')
-        password = self.get_param('smtp.password')
+        host = self.get_param('askomics.smtp_host')
+        port = self.get_param('askomics.smtp_port')
+        login = self.get_param('askomics.smtp_login')
+        password = self.get_param('askomics.smtp_password')
 
         msg = MIMEMultipart()
         msg['From'] = 'AskoMics@'+host_url
@@ -251,8 +251,8 @@ class ParamManager(object):
             smtp.set_debuglevel(1)
             if starttls:
                 smtp.ehlo()
-                smtp.starttls()
-            smtp.login(login, password)
+                askomics.smtp_starttls()
+            askomics.smtp_login(login, password)
             smtp.sendmail(dests[0], dests, msg.as_string())
             smtp.quit()
             self.log.debug("Successfully sent email")

--- a/askomics/libaskomics/rdfdb/QueryLauncher.py
+++ b/askomics/libaskomics/rdfdb/QueryLauncher.py
@@ -100,14 +100,14 @@ class QueryLauncher(ParamManager):
                 print(self.settings)
                 raise ValueError("askomics.endpoint")
 
-            if self.is_defined("askomics.endpoint.username") and self.is_defined("askomics.endpoint.passwd"):
-                user = self.get_param("askomics.endpoint.username")
-                passwd = self.get_param("askomics.endpoint.passwd")
+            if self.is_defined("askomics.endpoint_username") and self.is_defined("askomics.endpoint_passwd"):
+                user = self.get_param("askomics.endpoint_username")
+                passwd = self.get_param("askomics.endpoint_passwd")
                 data_endpoint.setCredentials(user, passwd)
-            elif self.is_defined("askomics.endpoint.username"):
-                raise ValueError("askomics.endpoint.username")
-            elif self.is_defined("askomics.endpoint.passwd"):
-                raise ValueError("askomics.endpoint.passwd")
+            elif self.is_defined("askomics.endpoint_username"):
+                raise ValueError("askomics.endpoint_username")
+            elif self.is_defined("askomics.endpoint_passwd"):
+                raise ValueError("askomics.endpoint_passwd")
 
             if self.is_defined("askomics.endpoint.auth"):
                 data_endpoint.setHTTPAuth(self.get_param("askomics.endpoint.auth")) # Basic or Digest

--- a/configs/development.agraph.ini
+++ b/configs/development.agraph.ini
@@ -19,8 +19,8 @@ askomics.debug = true
 # Triplestore configuration
 askomics.endpoint=http://localhost:10035/repositories/database/sparql
 askomics.hack_virtuoso = true
-askomics.endpoint.passwd=xyzzy
-askomics.endpoint.username=test
+askomics.endpoint_passwd=xyzzy
+askomics.endpoint_username=test
 askomics.max_content_size_to_update_database = 20000
 askomics.graph = urn:sparql:askomics
 askomics.users_graph = urn:sparql:askomics:users
@@ -34,7 +34,7 @@ askomics.overview_lines_limit = 200
 askomics.allowed_file_types = 'text/plain','text/csv','text/tab-separated-values','text/fasta'
 askomics.upload_min_size = 1
 askomics.upload_max_size = 200000000
-user.files.dir = /tmp/askomics
+askomics.files_dir = /tmp/askomics
 
 # Authentication
 askomics.salt = AskOmics
@@ -53,7 +53,11 @@ askomics.proxy_username = username
 askomics.proxy_password = password
 
 # SMTP Server
-#smtp.host=Sphinx
+#askomics.smtp_host=
+#askomics.smtp_port=
+#askomics.smtp_login=
+#askomics.smtp_password=
+#askomics.smtp_starttls=
 
 ###
 # wsgi server configuration

--- a/configs/development.corese.ini
+++ b/configs/development.corese.ini
@@ -32,7 +32,7 @@ askomics.overview_lines_limit = 200
 askomics.allowed_file_types = 'text/plain','text/csv','text/tab-separated-values','text/fasta'
 askomics.upload_min_size = 1
 askomics.upload_max_size = 200000000
-user.files.dir = /tmp/askomics
+askomics.files_dir = /tmp/askomics
 
 # Authentication
 askomics.salt = AskOmics
@@ -51,7 +51,11 @@ askomics.proxy_username = username
 askomics.proxy_password = password
 
 # SMTP Server
-#smtp.host=Sphinx
+#askomics.smtp_host=
+#askomics.smtp_port=
+#askomics.smtp_login=
+#askomics.smtp_password=
+#askomics.smtp_starttls=
 
 ###
 # wsgi server configuration

--- a/configs/development.fuseki.ini
+++ b/configs/development.fuseki.ini
@@ -33,7 +33,7 @@ askomics.overview_lines_limit = 200
 askomics.allowed_file_types = 'text/plain','text/csv','text/tab-separated-values','text/fasta'
 askomics.upload_min_size = 1
 askomics.upload_max_size = 200000000
-user.files.dir = /tmp/askomics
+askomics.files_dir = /tmp/askomics
 
 # Authentication
 askomics.salt = AskOmics
@@ -52,7 +52,11 @@ askomics.proxy_username = username
 askomics.proxy_password = password
 
 # SMTP Server
-#smtp.host=Sphinx
+#askomics.smtp_host=
+#askomics.smtp_port=
+#askomics.smtp_login=
+#askomics.smtp_password=
+#askomics.smtp_starttls=
 
 ###
 # wsgi server configuration

--- a/configs/development.stardog.ini
+++ b/configs/development.stardog.ini
@@ -35,8 +35,8 @@ askomics.graph=urn:sparql:askomics
 askomics.users_graph=urn:sparql:askomics:users
 
 askomics.endpoint = http://localhost:5820/test/query
-askomics.endpoint.username=admin
-askomics.endpoint.passwd=admin
+askomics.endpoint_username=admin
+askomics.endpoint_passwd=admin
 askomics.max_content_size_to_update_database = 20000
 askomics.hack_virtuoso = false
 
@@ -50,7 +50,7 @@ askomics.upload_max_size = 200000000
 # HTTP method used to delete uploaded files (can be POST or DELETE)
 askomics.delete_method = DELETE
 
-user.files.dir=/tmp/askomics
+askomics.files_dir=/tmp/askomics
 
 # Proxy setting
 # Set askomics.proxy to:
@@ -65,7 +65,11 @@ askomics.proxy_username = admin
 askomics.proxy_password = admin
 
 # SMTP Server
-smtp.host=Sphinx
+#askomics.smtp_host=
+#askomics.smtp_port=
+#askomics.smtp_login=
+#askomics.smtp_password=
+#askomics.smtp_starttls=
 
 ###
 # wsgi server configuration

--- a/configs/development.virtuoso.ini
+++ b/configs/development.virtuoso.ini
@@ -32,7 +32,7 @@ askomics.overview_lines_limit = 200
 askomics.allowed_file_types = 'text/plain','text/csv','text/tab-separated-values','text/fasta'
 askomics.upload_min_size = 1
 askomics.upload_max_size = 200000000
-user.files.dir = /tmp/askomics
+askomics.files_dir = /tmp/askomics
 
 # Authentication
 askomics.salt = AskOmics
@@ -51,16 +51,11 @@ askomics.proxy_username = username
 askomics.proxy_password = password
 
 # SMTP Server
-#smtp.host=localhost
-#smtp.port=25
-#smtp.login=admin
-#smtp.password=test
-
-#smtp.host=smtp.inria.fr
-#smtp.port=587
-#smtp.login=
-#smtp.password=
-#smtp.starttls=yes
+#askomics.smtp_host=
+#askomics.smtp_port=
+#askomics.smtp_login=
+#askomics.smtp_password=
+#askomics.smtp_starttls=
 
 ###
 # wsgi server configuration

--- a/configs/production.agraph.ini
+++ b/configs/production.agraph.ini
@@ -34,7 +34,7 @@ askomics.overview_lines_limit = 200
 askomics.allowed_file_types = 'text/plain','text/csv','text/tab-separated-values','text/fasta'
 askomics.upload_min_size = 1
 askomics.upload_max_size = 200000000
-user.files.dir = /tmp/askomics
+skomics.files_dir = /tmp/askomics
 
 # Authentication
 askomics.salt = AskOmics
@@ -53,7 +53,11 @@ askomics.proxy_username = username
 askomics.proxy_password = password
 
 # SMTP Server
-#smtp.host=Sphinx
+#askomics.smtp_host=
+#askomics.smtp_port=
+#askomics.smtp_login=
+#askomics.smtp_password=
+#askomics.smtp_starttls=
 
 ###
 # wsgi server configuration

--- a/configs/production.fuseki.ini
+++ b/configs/production.fuseki.ini
@@ -32,7 +32,7 @@ askomics.overview_lines_limit = 200
 askomics.allowed_file_types = 'text/plain','text/csv','text/tab-separated-values','text/fasta'
 askomics.upload_min_size = 1
 askomics.upload_max_size = 200000000
-user.files.dir = /tmp/askomics
+askomics.files_dir = /tmp/askomics
 
 # Authentication
 askomics.salt = AskOmics
@@ -51,7 +51,11 @@ askomics.proxy_username = username
 askomics.proxy_password = password
 
 # SMTP Server
-#smtp.host=Sphinx
+#askomics.smtp_host=
+#askomics.smtp_port=
+#askomics.smtp_login=
+#askomics.smtp_password=
+#askomics.smtp_starttls=
 
 ###
 # wsgi server configuration

--- a/configs/production.virtuoso.ini
+++ b/configs/production.virtuoso.ini
@@ -32,7 +32,7 @@ askomics.overview_lines_limit = 200
 askomics.allowed_file_types = 'text/plain','text/csv','text/tab-separated-values','text/fasta'
 askomics.upload_min_size = 1
 askomics.upload_max_size = 200000000
-user.files.dir = /tmp/askomics
+askomics.files_dir = /tmp/askomics
 
 # Authentication
 askomics.salt = AskOmics
@@ -51,7 +51,11 @@ askomics.proxy_username = username
 askomics.proxy_password = password
 
 # SMTP Server
-#smtp.host=Sphinx
+#askomics.smtp_host=
+#askomics.smtp_port=
+#askomics.smtp_login=
+#askomics.smtp_password=
+#askomics.smtp_starttls=
 
 ###
 # wsgi server configuration

--- a/configs/test.virtuoso.ini
+++ b/configs/test.virtuoso.ini
@@ -32,7 +32,7 @@ askomics.overview_lines_limit = 200
 askomics.allowed_file_types = 'text/plain','text/csv','text/tab-separated-values','text/fasta'
 askomics.upload_min_size = 1
 askomics.upload_max_size = 200000000
-user.files.dir = /tmp/askomics
+askomics.files_dir = /tmp/askomics
 
 # Authentication
 askomics.salt = AskOmics
@@ -51,7 +51,11 @@ askomics.proxy_username = username
 askomics.proxy_password = password
 
 # SMTP Server
-#smtp.host=Sphinx
+#askomics.smtp_host=
+#askomics.smtp_port=
+#askomics.smtp_login=
+#askomics.smtp_password=
+#askomics.smtp_starttls=
 
 ###
 # wsgi server configuration

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ requires = [
     'bcbio-gff',
     'validate_email',
     'pybedtools==0.7.10',
+    'configparser'
     ]
 
 setup(name='Askomics',


### PR DESCRIPTION
All askomics properties defined in section `[app:main]` of the `.ini`  file can be configured via the environment variables. The environment variable should be prefixed with `ASKO_`, without the `askomics.`

For exemple, if ou want to modify `askomics.overview_lines_limit = 200` of the ini file, you must declare a environment variable like  `ASKO_overview_lines_limit="1000"`

This work even if the entry is commented in the original file, and if it doesn't exist.

:warning: All value must be string ! No integer and no boolean.

:warning: :warning: Name of some ini property have change, So docker-compose who use the old way to update the ini property will soon be updated (askomics/askomics-docker-compose#5)
