### PR TITLE
Update all INI entry with Environment variables

### DIFF
--- a/askomics/ask_view.py
+++ b/askomics/ask_view.py
@@ -1319,7 +1319,10 @@ class AskView(object):
         param_manager = ParamManager(self.settings, self.request.session)
         param_manager.get_upload_directory()
 
-        return HTTPFound(self.request.application_url)
+        if self.request.application_url.endswith('/'):
+            return HTTPFound(self.request.application_url)
+
+        return HTTPFound(self.request.application_url + '/')
 
 
     @view_config(route_name='login_api', request_method='POST')

--- a/askomics/test/askView_test.py
+++ b/askomics/test/askView_test.py
@@ -552,6 +552,71 @@ class AskViewTests(unittest.TestCase):
 
         assert data == {'blocked': False, 'admin': True, 'error': [], 'username': 'jdoe'}
 
+    def test_login_api(self):
+        """Test login_api method"""
+
+        self.tps.clean_up()
+        # First, create a user
+        self.request.json_body = {
+            'username': 'jdoe',
+            'email': 'jdoe@exemple.com',
+            'password': 'iamjohndoe',
+            'password2': 'iamjohndoe'
+        }
+
+        self.askview.signup()
+
+        # Then, create an API key
+
+        self.request.json_body = {
+            'username': 'jdoe',
+            'keyname': 'test'
+        }
+
+        self.askview.api_key()
+
+        # then, get infos
+        infos = self.askview.get_my_infos()
+
+        # then, try to log with API key
+        self.request.json_body = {
+            'apikey': infos['apikeys'][0]['key']
+        }
+
+        data = self.askview.login_api()
+
+        assert data == {'admin': True, 'blocked': False, 'username': 'jdoe', 'sucess': 'success', 'error': ''}
+
+    def test_login_api_gie(self):
+        """Test login_api method"""
+
+        self.tps.clean_up()
+        # First, create a user
+        self.request.json_body = {
+            'username': 'jdoe',
+            'email': 'jdoe@exemple.com',
+            'password': 'iamjohndoe',
+            'password2': 'iamjohndoe'
+        }
+
+        self.askview.signup()
+
+        # Then, create an API key
+        self.request.json_body = {
+            'username': 'jdoe',
+            'keyname': 'test'
+        }
+
+        self.askview.api_key()
+
+        # then, get infos
+        infos = self.askview.get_my_infos()
+
+        # then, try to log with API key
+        self.request.GET['key'] = infos['apikeys'][0]['key']
+
+        self.askview.login_api_gie()
+
     def test_get_users_infos(self):
         """Test get_users_infos"""
 

--- a/config_updater.py
+++ b/config_updater.py
@@ -1,0 +1,32 @@
+import argparse
+import configparser
+
+
+def main():
+    """Update ini entry of a config file"""
+
+    parser = argparse.ArgumentParser(description='Update AskOmics config file')
+
+    parser.add_argument('-p', '--path', type=str, help='Path to config file', required=True)
+    parser.add_argument('-s', '--section', type=str, help='Section to add/update', required=True)
+    parser.add_argument('-k', '--key', type=str, help='Key to add into the section', required=True)
+    parser.add_argument('-v', '--value', type=str, help='Value of the key', required=True)
+
+    args = parser.parse_args()
+
+    path = args.path
+    section = args.section
+    key = args.key
+    value = args.value
+
+    config = configparser.ConfigParser()
+    config.read(path)
+
+    if section not in config.sections():
+        config.add_section(section)
+
+    config[section][key] = value
+    config.write(open(path, 'w'))
+
+if __name__ == '__main__':
+    main()

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,8 @@ requires = [
     'bioblend==0.9.0',
     'humanize',
     'pybedtools==0.7.10',
-    'configparser'
+    'configparser',
+    'argparse'
     ]
 
 setup(name='Askomics',

--- a/startAskomics.sh
+++ b/startAskomics.sh
@@ -99,9 +99,11 @@ echo "Convert environment variables to ini file ..."
 cp "$dir_config/$depmode.$triplestore.ini" "$config_path"
 printenv | egrep "^ASKO_" | while read setting
 do
-    key="askomics."$(echo $setting | egrep -o "^ASKO_[^=]+" | sed 's/^.\{5\}//g' | tr '[:upper:]' '[:lower:]')
-    value=$(echo $setting | egrep -o "=.*$" | sed 's/^=//g')
-    $python_ex -c "import configparser; config = configparser.ConfigParser(); config.read('"$config_path"'); config['app:main']['"$key"'] = '"$value"'; config.write(open('"$config_path"', 'w'))"
+    sed_setting=$(echo $setting | sed 's/\_colon\_/\:/g' | sed 's/\_hyphen\_/\-/g' | sed 's/\_dot\_/\./g')
+    section=$(echo $sed_setting | egrep -o "^ASKO_[^=]+" | sed 's/^.\{5\}//g' | cut -d "_" -f 1 | tr '[:upper:]' '[:lower:]')
+    key=$(echo $sed_setting | egrep -o "^ASKO_[^=]+" | sed 's/^.\{5\}//g' | sed "s/$section\_//g" | tr '[:upper:]' '[:lower:]')
+    value=$(echo $sed_setting | egrep -o "=.*$" | sed 's/^=//g' | tr '[:upper:]' '[:lower:]')
+    $python_ex -c "import configparser; config = configparser.ConfigParser(); config.read('"$config_path"'); config['"$section"']['"$key"'] = '"$value"'; config.write(open('"$config_path"', 'w'))"
 done
 
 # Build Javascript ----------------------------------------

--- a/startAskomics.sh
+++ b/startAskomics.sh
@@ -103,7 +103,7 @@ printenv | egrep "^ASKO_" | while read setting
 do
     key="askomics."$(echo $setting | egrep -o "^ASKO_[^=]+" | sed 's/^.\{5\}//g' | tr '[:upper:]' '[:lower:]')
     value=$(echo $setting | egrep -o "=.*$" | sed 's/^=//g')
-    $python_ex -c "import configparser; config = configparser.ConfigParser(); config.read('"$config_path"'); config['app:main']['"$key"'] = '"$value"'; config.write(open('"$config_path"', 'w'))"
+    $python_ex config_updater.py -p $config_path -s "app:main" -k $key -v $value
 done
 
 # This take ASKOCONFIG_ env to update config in any sections
@@ -113,7 +113,7 @@ do
     section=$(echo $sed_setting | egrep -o "^ASKOCONFIG_[^=]+" | sed 's/^.\{11\}//g' | cut -d "_" -f 1 | tr '[:upper:]' '[:lower:]')
     key=$(echo $sed_setting | egrep -o "^ASKOCONFIG_[^=]+" | sed 's/^.\{11\}//g' | sed "s/$section\_//g" | tr '[:upper:]' '[:lower:]')
     value=$(echo $sed_setting | egrep -o "=.*$" | sed 's/^=//g' | tr '[:upper:]' '[:lower:]')
-    $python_ex -c "import configparser; config = configparser.ConfigParser(); config.read('"$config_path"'); config.add_section('"$section"') if '"$section"' not in config.sections() else None; config['"$section"']['"$key"'] = '"$value"'; config.write(open('"$config_path"', 'w'))"
+    $python_ex config_updater.py -p $config_path -s $section -k $key -v $value
 done
 
 # Build Javascript ----------------------------------------

--- a/startAskomics.sh
+++ b/startAskomics.sh
@@ -100,20 +100,20 @@ cp "$dir_config/$depmode.$triplestore.ini" "$config_path"
 
 # This take ASKO_ env to update config in app:main section, only askomics. key
 printenv | egrep "^ASKO_" | while read setting
+do
     key="askomics."$(echo $setting | egrep -o "^ASKO_[^=]+" | sed 's/^.\{5\}//g' | tr '[:upper:]' '[:lower:]')
     value=$(echo $setting | egrep -o "=.*$" | sed 's/^=//g')
     $python_ex -c "import configparser; config = configparser.ConfigParser(); config.read('"$config_path"'); config['app:main']['"$key"'] = '"$value"'; config.write(open('"$config_path"', 'w'))"
-
 done
 
 # This take ASKOCONFIG_ env to update config in any sections
 printenv | egrep "^ASKOCONFIG_" | while read setting
 do
     sed_setting=$(echo $setting | sed 's/\_colon\_/\:/g' | sed 's/\_hyphen\_/\-/g' | sed 's/\_dot\_/\./g')
-    section=$(echo $sed_setting | egrep -o "^ASKOCONFIG_[^=]+" | sed 's/^.\{5\}//g' | cut -d "_" -f 1 | tr '[:upper:]' '[:lower:]')
-    key=$(echo $sed_setting | egrep -o "^ASKOCONFIG_[^=]+" | sed 's/^.\{5\}//g' | sed "s/$section\_//g" | tr '[:upper:]' '[:lower:]')
+    section=$(echo $sed_setting | egrep -o "^ASKOCONFIG_[^=]+" | sed 's/^.\{11\}//g' | cut -d "_" -f 1 | tr '[:upper:]' '[:lower:]')
+    key=$(echo $sed_setting | egrep -o "^ASKOCONFIG_[^=]+" | sed 's/^.\{11\}//g' | sed "s/$section\_//g" | tr '[:upper:]' '[:lower:]')
     value=$(echo $sed_setting | egrep -o "=.*$" | sed 's/^=//g' | tr '[:upper:]' '[:lower:]')
-    $python_ex -c "import configparser; config = configparser.ConfigParser(); config.read('"$config_path"'); config['"$section"']['"$key"'] = '"$value"'; config.write(open('"$config_path"', 'w'))"
+    $python_ex -c "import configparser; config = configparser.ConfigParser(); config.read('"$config_path"'); config.add_section('"$section"') if '"$section"' not in config.sections() else None; config['"$section"']['"$key"'] = '"$value"'; config.write(open('"$config_path"', 'w'))"
 done
 
 # Build Javascript ----------------------------------------

--- a/startAskomics.sh
+++ b/startAskomics.sh
@@ -97,11 +97,21 @@ config_path="$dir_config/$config_name"
 
 echo "Convert environment variables to ini file ..."
 cp "$dir_config/$depmode.$triplestore.ini" "$config_path"
+
+# This take ASKO_ env to update config in app:main section, only askomics. key
 printenv | egrep "^ASKO_" | while read setting
+    key="askomics."$(echo $setting | egrep -o "^ASKO_[^=]+" | sed 's/^.\{5\}//g' | tr '[:upper:]' '[:lower:]')
+    value=$(echo $setting | egrep -o "=.*$" | sed 's/^=//g')
+    $python_ex -c "import configparser; config = configparser.ConfigParser(); config.read('"$config_path"'); config['app:main']['"$key"'] = '"$value"'; config.write(open('"$config_path"', 'w'))"
+
+done
+
+# This take ASKOCONFIG_ env to update config in any sections
+printenv | egrep "^ASKOCONFIG_" | while read setting
 do
     sed_setting=$(echo $setting | sed 's/\_colon\_/\:/g' | sed 's/\_hyphen\_/\-/g' | sed 's/\_dot\_/\./g')
-    section=$(echo $sed_setting | egrep -o "^ASKO_[^=]+" | sed 's/^.\{5\}//g' | cut -d "_" -f 1 | tr '[:upper:]' '[:lower:]')
-    key=$(echo $sed_setting | egrep -o "^ASKO_[^=]+" | sed 's/^.\{5\}//g' | sed "s/$section\_//g" | tr '[:upper:]' '[:lower:]')
+    section=$(echo $sed_setting | egrep -o "^ASKOCONFIG_[^=]+" | sed 's/^.\{5\}//g' | cut -d "_" -f 1 | tr '[:upper:]' '[:lower:]')
+    key=$(echo $sed_setting | egrep -o "^ASKOCONFIG_[^=]+" | sed 's/^.\{5\}//g' | sed "s/$section\_//g" | tr '[:upper:]' '[:lower:]')
     value=$(echo $sed_setting | egrep -o "=.*$" | sed 's/^=//g' | tr '[:upper:]' '[:lower:]')
     $python_ex -c "import configparser; config = configparser.ConfigParser(); config.read('"$config_path"'); config['"$section"']['"$key"'] = '"$value"'; config.write(open('"$config_path"', 'w'))"
 done

--- a/startAskomics.sh
+++ b/startAskomics.sh
@@ -110,9 +110,9 @@ done
 printenv | egrep "^ASKOCONFIG_" | while read setting
 do
     sed_setting=$(echo $setting | sed 's/\_colon\_/\:/g' | sed 's/\_hyphen\_/\-/g' | sed 's/\_dot\_/\./g')
-    section=$(echo $sed_setting | egrep -o "^ASKOCONFIG_[^=]+" | sed 's/^.\{11\}//g' | cut -d "_" -f 1 | tr '[:upper:]' '[:lower:]')
-    key=$(echo $sed_setting | egrep -o "^ASKOCONFIG_[^=]+" | sed 's/^.\{11\}//g' | sed "s/$section\_//g" | tr '[:upper:]' '[:lower:]')
-    value=$(echo $sed_setting | egrep -o "=.*$" | sed 's/^=//g' | tr '[:upper:]' '[:lower:]')
+    section=$(echo $sed_setting | egrep -o "^ASKOCONFIG_[^=]+" | sed 's/^.\{11\}//g' | cut -d "_" -f 1)
+    key=$(echo $sed_setting | egrep -o "^ASKOCONFIG_[^=]+" | sed 's/^.\{11\}//g' | sed "s/$section\_//g")
+    value=$(echo $sed_setting | egrep -o "=.*$" | sed 's/^=//g')
     $python_ex config_updater.py -p $config_path -s $section -k $key -v $value
 done
 


### PR DESCRIPTION
All ini entry can be updated with environment variables

Environment variables have to be like:
```bash
ASKOCONFIG_section_key=value
```
As variables can not have special characters, they have to be replaced according the following table: 

|character|replacement|
|---|---|
 :|\_colon\_|
|.|\_dot\_|
|-|\_hyphen\_|

examples:

```bash
export ASKOCONFIG_app_colon_main_filter_hyphen_with="proxy-prefix"
export ASKOCONFIG_filter_colon_proxyprefix_use="egg:PasteDeploy#prefix"
export ASKOCONFIG_filter_colon_proxyprefix_prefix="/gie_proxy/askomics"
```

Will create in the ini file:
```ini
[app:main]
filter-with = proxy-prefix
[filter:proxyprefix]
use = egg:PasteDeploy#prefix
prefix = /gie_proxy/askomics
```

This change is needed for the Galaxy Virtual environment.

**EDIT:**

We keep the old way to manage config env variables:
```bash
ASKO_key=value
```
for 

```ini
[app:main]
askomics.key = value
```
and
```bash
ASKOCONFIG_section_key=value
```
for

```ini
[section]
key = value
```
