### PR TITLE
Look for tsv datatype too in Galaxy histories

### DIFF
--- a/askomics/static/src/js/core/IHMLocal.js
+++ b/askomics/static/src/js/core/IHMLocal.js
@@ -527,7 +527,7 @@ class IHMLocal {
             title = 'Get a dataset from Galaxy';
             radio = true;
             input_type = 'checkbox';
-            allowed_files = ['tabular', 'ttl', 'gff', 'gff3', 'gff2', 'bed'];
+            allowed_files = ['tabular', 'tsv', 'ttl', 'gff', 'gff3', 'gff2', 'bed'];
         }else{
             // Query file upload
             title = 'Get a query from Galaxy';


### PR DESCRIPTION
ping @ofilangi 
Some tools seems to produce datasets of type "tsv" instead of "tabular", so here's a little (untested) change to display this type of files too