### PR TITLE
Added configuration to make Corese federated query engine compatible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,21 +11,17 @@ install:
   - pip install coveralls
   - python setup.py install
 before_script:
-  - docker pull tenforce/virtuoso
+  - docker pull askomics/virtuoso
   - docker pull bgruening/galaxy-stable
   - docker pull askomics/fedx4askomics:rdf4j
   - docker pull xgaia/corese
   - sudo docker run --name corese -p 5050:8080 -d xgaia/corese
   - sudo docker run --name fedx -p 4040:4040 -d askomics/fedx4askomics:rdf4j
-  - sudo docker run -d --name virtuoso -p 127.0.0.1:8890:8890 -p 127.0.0.1:1111:1111  -e DBA_PASSWORD=dba -e SPARQL_UPDATE=true -e DEFAULT_GRAPH=http://localhost:8890/DAV --net="host" -t tenforce/virtuoso
-  - sudo docker run -d --name virtuoso2 -p 127.0.0.1:8891:8890 -p 127.0.0.1:1112:1111  -e DBA_PASSWORD=dba -e SPARQL_UPDATE=true -e DEFAULT_GRAPH=http://localhost:8891/DAV --net="host" -t tenforce/virtuoso
-  - sudo docker run -d --name galaxy -p 8080:80 -p 8021:21 -p 8022:22 bgruening/galaxy-stable
+  - sudo docker run -d --name virtuoso -p 8890:8890 -e DBA_PASSWORD=dba -e SPARQL_UPDATE=true -e DEFAULT_GRAPH=http://localhost:8890/DAV --net="host" -t askomics/virtuoso
+  - sudo docker run -d --name virtuoso2 -p 8891:8890 -e DBA_PASSWORD=dba -e SPARQL_UPDATE=true -e DEFAULT_GRAPH=http://localhost:8891/DAV --net="host" -t askomics/virtuoso
+  - sudo docker run -d --name galaxy -p 8080:80 bgruening/galaxy-stable
   - sleep 1m
-  - docker ps -a
-  - docker logs galaxy
 script:
   - python setup.py nosetests
-# - gulp test
-#  - coveralls-lcov -v -n coverage/frontend.lcov > coverage.json
 after_success:
   coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,12 @@ install:
 before_script:
   - docker pull tenforce/virtuoso
   - docker pull bgruening/galaxy-stable
+  - docker pull askomics/fedx4askomics:rdf4j
+  - docker pull xgaia/corese
+  - sudo docker run --name corese -p 5050:8080 -d xgaia/corese
+  - sudo docker run --name fedx -p 4040:4040 - askomics/fedx4askomics:rdf4j
   - sudo docker run -d --name virtuoso -p 127.0.0.1:8890:8890 -p 127.0.0.1:1111:1111  -e DBA_PASSWORD=dba -e SPARQL_UPDATE=true -e DEFAULT_GRAPH=http://localhost:8890/DAV --net="host" -t tenforce/virtuoso
+  - sudo docker run -d --name virtuoso2 -p 127.0.0.1:8891:8890 -p 127.0.0.1:1112:1111  -e DBA_PASSWORD=dba -e SPARQL_UPDATE=true -e DEFAULT_GRAPH=http://localhost:8891/DAV --net="host" -t tenforce/virtuoso
   - sudo docker run -d --name galaxy -p 8080:80 -p 8021:21 -p 8022:22 bgruening/galaxy-stable
   - sleep 1m
   - docker ps -a

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_script:
   - docker pull askomics/fedx4askomics:rdf4j
   - docker pull xgaia/corese
   - sudo docker run --name corese -p 5050:8080 -d xgaia/corese
-  - sudo docker run --name fedx -p 4040:4040 - askomics/fedx4askomics:rdf4j
+  - sudo docker run --name fedx -p 4040:4040 -d askomics/fedx4askomics:rdf4j
   - sudo docker run -d --name virtuoso -p 127.0.0.1:8890:8890 -p 127.0.0.1:1111:1111  -e DBA_PASSWORD=dba -e SPARQL_UPDATE=true -e DEFAULT_GRAPH=http://localhost:8890/DAV --net="host" -t tenforce/virtuoso
   - sudo docker run -d --name virtuoso2 -p 127.0.0.1:8891:8890 -p 127.0.0.1:1112:1111  -e DBA_PASSWORD=dba -e SPARQL_UPDATE=true -e DEFAULT_GRAPH=http://localhost:8891/DAV --net="host" -t tenforce/virtuoso
   - sudo docker run -d --name galaxy -p 8080:80 -p 8021:21 -p 8022:22 bgruening/galaxy-stable

--- a/askomics/ask_view.py
+++ b/askomics/ask_view.py
@@ -31,7 +31,6 @@ from askomics.libaskomics.rdfdb.SparqlQueryAuth import SparqlQueryAuth
 
 from askomics.libaskomics.rdfdb.QueryLauncher import QueryLauncher
 from askomics.libaskomics.rdfdb.MultipleQueryLauncher import MultipleQueryLauncher
-from askomics.libaskomics.rdfdb.FederationQueryLauncher import FederationQueryLauncher
 
 from askomics.libaskomics.source_file.SourceFile import SourceFile
 from askomics.libaskomics.source_file.SourceFileURL import SourceFileURL

--- a/askomics/libaskomics/TripleStoreExplorer.py
+++ b/askomics/libaskomics/TripleStoreExplorer.py
@@ -195,6 +195,10 @@ class TripleStoreExplorer(ParamManager):
                     lE.append(end)
 
 
+                self.log.debug('+++++ lE +++++')
+                self.log.debug(lE)
+
+
                 query_launcher = FederationQueryLauncher(self.settings, self.session,lE)
             req = sqb.custom_query(fromgraphs, select, query,externalrequest=extreq, federation=True)
             results = query_launcher.process_query(req)

--- a/askomics/libaskomics/TripleStoreExplorer.py
+++ b/askomics/libaskomics/TripleStoreExplorer.py
@@ -194,11 +194,6 @@ class TripleStoreExplorer(ParamManager):
                     end['password'] = None
                     lE.append(end)
 
-
-                self.log.debug('+++++ lE +++++')
-                self.log.debug(lE)
-
-
                 query_launcher = FederationQueryLauncher(self.settings, self.session,lE)
             req = sqb.custom_query(fromgraphs, select, query,externalrequest=extreq, federation=True)
             results = query_launcher.process_query(req)

--- a/askomics/libaskomics/TripleStoreExplorer.py
+++ b/askomics/libaskomics/TripleStoreExplorer.py
@@ -196,7 +196,7 @@ class TripleStoreExplorer(ParamManager):
 
 
                 query_launcher = FederationQueryLauncher(self.settings, self.session,lE)
-            req = sqb.custom_query(fromgraphs, select, query,externalrequest=extreq)
+            req = sqb.custom_query(fromgraphs, select, query,externalrequest=extreq, federation=True)
             results = query_launcher.process_query(req)
         else:
             results = []

--- a/askomics/libaskomics/rdfdb/FederationQueryLauncher.py
+++ b/askomics/libaskomics/rdfdb/FederationQueryLauncher.py
@@ -26,9 +26,6 @@ class FederationQueryLauncher(QueryLauncher):
 
 
         self.log.debug(" =================== Federation Request ====================")
-        self.log.debug('°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°')
-
-        self.log.debug(list_endpoints)
 
         # comments added in sparql request to get all url endpoint.
         if self.settings['askomics.federation_engine'] == "corese":
@@ -65,7 +62,6 @@ class FederationQueryLauncher(QueryLauncher):
         '''
         self.log.debug("================================================================================")
         self.log.debug(" =================== Federation Request : process_query  ====================")
-        self.log.debug(query)
         self.log.debug("================================================================================")
 
         # Federation Request case

--- a/askomics/libaskomics/rdfdb/FederationQueryLauncher.py
+++ b/askomics/libaskomics/rdfdb/FederationQueryLauncher.py
@@ -20,30 +20,33 @@ class FederationQueryLauncher(QueryLauncher):
           from these preformated results using a ResultsBuilder instance.
     """
 
-    def __init__(self, settings, session,lendpoints):
+    def __init__(self, settings, session, list_endpoints):
         QueryLauncher.__init__(self, settings, session)
         self.log = logging.getLogger(__name__)
 
 
         self.log.debug(" =================== Federation Request ====================")
+        self.log.debug('°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°°')
 
-        #comments added in sparql request to get all url endpoint.
+        self.log.debug(list_endpoints)
+
+        # comments added in sparql request to get all url endpoint.
         if self.settings['askomics.federation_engine'] == "corese":
-            self.commentsForFed = "@trap@federate\n"  # @trap ignore results parsing errors and write it in Corese logs
-            for endp in lendpoints:
-                self.commentsForFed += "<" + endp['endpoint'] + ">\n"
+            self.federation_header = "@trap@federate\n"  # @trap ignore results parsing errors and write it in Corese logs
+            for endpoint in list_endpoints:
+                self.federation_header += "<" + endpoint['endpoint'] + ">\n"
 
         if self.settings['askomics.federation_engine'] == "fedx":
-            self.commentsForFed=""
-            for endp in lendpoints:
-                if 'askomics' not in endp:
-                   raise ValueError("endpoint var have to defined an 'askomics' key with a boolean value endp="+str(endp))
-                if endp['askomics']:
-                   self.commentsForFed+="#endpoint,askomics,"+endp['name']+','+endp['endpoint']+',false\n'
+            self.federation_header = ""
+            for endpoint in list_endpoints:
+                if 'askomics' not in endpoint:
+                   raise ValueError("endpoint var have to defined an 'askomics' key with a boolean value endpoint = " + str(endpoint))
+                if endpoint['askomics']:
+                   self.federation_header += "#endpoint,askomics," + endpoint['name'] + ',' + endpoint['endpoint'] + ',false\n'
                 else:
-                   self.commentsForFed+="#endpoint,external,"+endp['name']+','+endp['endpoint']+',false\n'
+                   self.federation_header += "#endpoint,external," + endpoint['name'] + ',' + endpoint['endpoint'] + ',false\n' 
             #add local TPS
-            #self.commentsForFed+="#endpoint,local,"+self.get_param("askomics.endpoint")+',false\n'
+            #self.federation_header += "#endpoint,local," + self.get_param("askomics.endpoint") + ',false\n'
 
         if not self.is_defined("askomics.federation_url") :
             raise ValueError("can not find askomics.federation_url property in the config file !")
@@ -62,10 +65,11 @@ class FederationQueryLauncher(QueryLauncher):
         '''
         self.log.debug("================================================================================")
         self.log.debug(" =================== Federation Request : process_query  ====================")
+        self.log.debug(query)
         self.log.debug("================================================================================")
 
         # Federation Request case
         #------------------------------------------------------
-        query = self.commentsForFed + query
-        json_query = self._execute_query(query,log_raw_results=False)
+        query = self.federation_header + query
+        json_query = self._execute_query(query, log_raw_results=False)
         return self.parse_results(json_query)

--- a/askomics/libaskomics/rdfdb/FederationQueryLauncher.py
+++ b/askomics/libaskomics/rdfdb/FederationQueryLauncher.py
@@ -28,22 +28,28 @@ class FederationQueryLauncher(QueryLauncher):
         self.log.debug(" =================== Federation Request ====================")
 
         #comments added in sparql request to get all url endpoint.
-        self.commentsForFed=""
-        for endp in lendpoints:
-            if 'askomics' not in endp:
-                raise ValueError("endpoint var have to defined an 'askomics' key with a boolean value endp="+str(endp))
-            if endp['askomics']:
-                self.commentsForFed+="#endpoint,askomics,"+endp['name']+','+endp['endpoint']+',false\n'
-            else:
-                self.commentsForFed+="#endpoint,external,"+endp['name']+','+endp['endpoint']+',false\n'
-        #add local TPS
-        #self.commentsForFed+="#endpoint,local,"+self.get_param("askomics.endpoint")+',false\n'
+        if self.settings['askomics.federation_engine'] == "corese":
+            self.commentsForFed = "@trap@federate\n"  # @trap ignore results parsing errors and write it in Corese logs
+            for endp in lendpoints:
+                self.commentsForFed += "<" + endp['endpoint'] + ">\n"
 
-        if not self.is_defined("askomics.fdendpoint") :
-            raise ValueError("can not find askomics.fdendpoint property in the config file !")
+        if self.settings['askomics.federation_engine'] == "fedx":
+            self.commentsForFed=""
+            for endp in lendpoints:
+                if 'askomics' not in endp:
+                   raise ValueError("endpoint var have to defined an 'askomics' key with a boolean value endp="+str(endp))
+                if endp['askomics']:
+                   self.commentsForFed+="#endpoint,askomics,"+endp['name']+','+endp['endpoint']+',false\n'
+                else:
+                   self.commentsForFed+="#endpoint,external,"+endp['name']+','+endp['endpoint']+',false\n'
+            #add local TPS
+            #self.commentsForFed+="#endpoint,local,"+self.get_param("askomics.endpoint")+',false\n'
+
+        if not self.is_defined("askomics.federation_url") :
+            raise ValueError("can not find askomics.federation_url property in the config file !")
 
         self.name = 'FederationEngine'
-        self.endpoint = self.get_param("askomics.fdendpoint")
+        self.endpoint = self.get_param("askomics.federation_url")
         self.username = None
         self.password = None
         self.urlupdate = None

--- a/askomics/libaskomics/rdfdb/SparqlQueryBuilder.py
+++ b/askomics/libaskomics/rdfdb/SparqlQueryBuilder.py
@@ -196,8 +196,12 @@ class SparqlQueryBuilder(ParamManager):
         if 'post_action' in replacement:
             query += replacement['post_action'] + "\n"
 
-        prefixes = self.header_sparql_config(query)
-        return prefixes + query
+        #Corese sparql endpoint does not support prefixes
+        if self.settings['askomics.federation_engine'] != "corese":
+            prefixes = self.header_sparql_config(query)
+            return prefixes + query
+        else:
+            return query
 
 
     def custom_query(self, fromgraph, select, query,externalrequest=False,adminrequest=False):

--- a/askomics/libaskomics/rdfdb/SparqlQueryBuilder.py
+++ b/askomics/libaskomics/rdfdb/SparqlQueryBuilder.py
@@ -152,7 +152,7 @@ class SparqlQueryBuilder(ParamManager):
         return settings
 
 
-    def build_query_on_the_fly(self, replacement, adminrequest=False, externalrequest= False):
+    def build_query_on_the_fly(self, replacement, adminrequest=False, externalrequest= False, federation=False):
         """
         Build a query from the private or public template
         """
@@ -197,14 +197,14 @@ class SparqlQueryBuilder(ParamManager):
             query += replacement['post_action'] + "\n"
 
         #Corese sparql endpoint does not support prefixes
-        if self.settings['askomics.federation_engine'] != "corese":
+        if self.settings['askomics.federation_engine'] == "corese" and federation == True:
+            return query
+        else:
             prefixes = self.header_sparql_config(query)
             return prefixes + query
-        else:
-            return query
 
 
-    def custom_query(self, fromgraph, select, query,externalrequest=False,adminrequest=False):
+    def custom_query(self, fromgraph, select, query,externalrequest=False,adminrequest=False, federation=False):
         """
         launch a custom query.
         """
@@ -215,7 +215,7 @@ class SparqlQueryBuilder(ParamManager):
             'from' : fromgraph,
             'select': select,
             'query': query
-        },externalrequest=exr,adminrequest=ar)
+        },externalrequest=exr,adminrequest=ar, federation=federation)
 
     def get_delete_query_string(self, graph):
         """

--- a/askomics/libaskomics/rdfdb/SparqlQueryBuilder.py
+++ b/askomics/libaskomics/rdfdb/SparqlQueryBuilder.py
@@ -198,6 +198,7 @@ class SparqlQueryBuilder(ParamManager):
 
         #Corese sparql endpoint does not support prefixes
         if self.settings['askomics.federation_engine'] == "corese" and federation == True:
+            ## TODO : replace "askomics:" prefix in query
             return query
         else:
             prefixes = self.header_sparql_config(query)

--- a/askomics/test-data/people2.tsv
+++ b/askomics/test-data/people2.tsv
@@ -1,0 +1,2 @@
+People	First_name	Last_name	Sex	Age
+p7	David	Gilmour	M	72

--- a/askomics/test/FederationQueryLauncher_test.py
+++ b/askomics/test/FederationQueryLauncher_test.py
@@ -17,7 +17,7 @@ class FederationQueryLauncherTests(unittest.TestCase):
         self.settings = get_appsettings('configs/tests.ini', name='main')
 
         self.request = testing.DummyRequest()
-        self.settings['askomics.fdendpoint'] = 'http://localhost:8890/sparql'
+        self.settings['askomics.federation_url'] = 'http://localhost:8080/sparql'
 
     def test_process_query(self):
         jm = EndpointManager(self.settings, self.request.session)

--- a/askomics/test/FederationQueryLauncher_test.py
+++ b/askomics/test/FederationQueryLauncher_test.py
@@ -17,15 +17,23 @@ class FederationQueryLauncherTests(unittest.TestCase):
         self.settings = get_appsettings('configs/tests.ini', name='main')
 
         self.request = testing.DummyRequest()
-        self.settings['askomics.federation_url'] = 'http://localhost:8080/sparql'
+
+
+
 
     def test_process_query(self):
         jm = EndpointManager(self.settings, self.request.session)
+        jm.remove_endpoint(1)
         jm.save_endpoint("testNameEndpoint",'http://localhost:8890/sparql','Digest',True)
+        jm.save_endpoint("testNameEndpoint2", 'http://localhost:8891/sparql', 'Digest', True)
+
+        # Test FedX
+        self.settings['askomics.federation_engine'] = 'fedx'
+        self.settings['askomics.federation_url'] = 'http://localhost:4040/fedx'
 
         try:
             fql = FederationQueryLauncher(self.settings, self.request.session,jm.list_endpoints())
-            fql.process_query("SELECT * WHERE { ?a ?b ?c. } LIMIT 1")
+            fql.process_query("SELECT * WHERE { ?a ?b ?c. LIMIT 1}")
             assert False
         except ValueError:
             assert True
@@ -41,3 +49,22 @@ class FederationQueryLauncherTests(unittest.TestCase):
         except ValueError as e:
             print(str(e))
             assert False
+
+
+        # Test Corese
+        # self.settings['askomics.federation_engine'] = 'corese'
+        # self.settings['askomics.federation_url'] = 'http://localhost:5050/sparql'
+        # try:
+        #     fql = FederationQueryLauncher(self.settings, self.request.session,jm.list_endpoints())
+        #     fql.process_query("SELECT * WHERE { ?a ?b ?c. } LIMIT 1")
+        #     assert False
+        # except ValueError:
+        #     assert True
+        #
+        # try:
+        #     fql = FederationQueryLauncher(self.settings, self.request.session,lE)
+        #     fql.process_query("SELECT * WHERE { ?a ?b ?c. } LIMIT 1")
+        #     assert True
+        # except ValueError as e:
+        #     print(str(e))
+        #     assert False

--- a/askomics/test/MultipleQueryLauncher_test.py
+++ b/askomics/test/MultipleQueryLauncher_test.py
@@ -17,7 +17,7 @@ class MultipleQueryLauncher(unittest.TestCase):
         self.settings = get_appsettings('configs/tests.ini', name='main')
 
         self.request = testing.DummyRequest()
-        #self.settings['askomics.fdendpoint'] = 'http://localhost:8890/sparql'
+        #self.settings['askomics.federation_url'] = 'http://localhost:8080/sparql'
 
     def test_process_query(self):
         jm = EndpointManager(self.settings, self.request.session)

--- a/askomics/test/SetupTests.py
+++ b/askomics/test/SetupTests.py
@@ -14,7 +14,7 @@ class SetupTests():
         session['upload_directory'] = self.temp_directory
         # Copy files if directory is empty
         if not os.listdir(self.temp_directory):
-            files = ['people.tsv', 'instruments.tsv', 'play_instrument.tsv', 'transcript.tsv', 'qtl.tsv', 'small_data.gff3', 'turtle_data.ttl', 'bed_example.bed']
+            files = ['people.tsv', 'people2.tsv', 'instruments.tsv', 'play_instrument.tsv', 'transcript.tsv', 'qtl.tsv', 'small_data.gff3', 'turtle_data.ttl', 'bed_example.bed']
             for file in files:
                 src = os.path.join(os.path.dirname(__file__), "..", "test-data") + '/' + file
                 dst = session['upload_directory'] + file

--- a/askomics/test/interface_tps_db.py
+++ b/askomics/test/interface_tps_db.py
@@ -103,7 +103,7 @@ class InterfaceTpsDb(object):
 
         src_file.set_forced_column_types(col_types)
         src_file.set_disabled_columns(disabled_columns)
-        src_file.set_param("askomics.upload_user_data_method",'insert')
+        src_file.set_param('askomics.upload_user_data_method', 'insert')
         src_file.persist('', public)
 
         return src_file.get_timestamp()
@@ -118,6 +118,17 @@ class InterfaceTpsDb(object):
         col_types = ['entity_start', 'text', 'text', 'category', 'numeric']
         uri_set = {'0': 'http://www.semanticweb.org/user/ontologies/2018/1#', '1': None, '2': None, '3': None, '4': None}
         return self.load_file("people.tsv", col_types, uri_set)
+
+    def load_people2(self):
+        """Load the file people2.tsv
+
+        :returns: the timestamp associated
+        :rtype: string
+        """
+
+        col_types = ['entity_start', 'text', 'text', 'category', 'numeric']
+        uri_set = {'0': 'http://www.semanticweb.org/user/ontologies/2018/1#', '1': None, '2': None, '3': None, '4': None}
+        return self.load_file("people2.tsv", col_types, uri_set, True)
 
     def load_instruments(self):
         """Load the file instruments.tsv
@@ -331,6 +342,22 @@ class InterfaceTpsDb(object):
             "otheradmin_apikey",
             "true",
             "false"
+        )
+        '''
+
+        database.execute_sql_query(query)
+
+    def add_askoko_in_endpoint(self):
+
+        database = DatabaseConnector(self.settings, self.request.session)
+        query = '''
+        INSERT INTO endpoints VALUES (
+            NULL,
+            "askoko",
+            "http://localhost:8891/sparql",
+            "BASIC",
+            "1",
+            NULL
         )
         '''
 

--- a/configs/askomics.ini.template
+++ b/configs/askomics.ini.template
@@ -37,10 +37,11 @@ askomics.triplestore_results_max_rows=10000
 
 
 # Federation Configuration
-askomics.federation_engine=corese
-askomics.federation_url=http://localhost:8080/sparql
-# fedx = http://localhost:4040/fedx
-# corese = http://localhost:8080/
+# - federation_engine: fedx or corese
+# - federation_url: url of the federated query engine
+#askomics.federation_engine=
+#askomics.federation_url=
+
 
 # AskOmics configuration
 # - files_dir: where AskOmics write user data

--- a/configs/askomics.ini.template
+++ b/configs/askomics.ini.template
@@ -36,9 +36,11 @@ askomics.delete_method = DELETE
 askomics.triplestore_results_max_rows=10000
 
 
-# Fedex Configuration
-askomics.fdendpoint=http://localhost:4040/fedx
-
+# Federation Configuration
+askomics.federation_engine=corese
+askomics.federation_url=http://localhost:8080/sparql
+# fedx = http://localhost:4040/fedx
+# corese = http://localhost:8080/
 
 # AskOmics configuration
 # - files_dir: where AskOmics write user data

--- a/configs/tests.ini
+++ b/configs/tests.ini
@@ -28,6 +28,12 @@ askomics.delete_method = DELETE
 #askomics.triplestore_results_max_rows=
 #can be POST or DELETE
 
+# Federation Configuration
+askomics.federation_engine = corese
+askomics.federation_url = http://localhost:8080/sparql
+# fedx = http://localhost:4040/fedx
+# corese = http://localhost:8080/sparql
+
 # AskOmics configuration
 askomics.overview_lines_limit = 200
 askomics.allowed_file_types = 'application/ld+json','text/xml','application/octet-stream','text/turtle','application/x-turtle','text/rdf+n3','text/plain','text/csv','text/tab-separated-values','text/fasta','application/rdf+xml, application/vnd.realvnc.bed'


### PR DESCRIPTION
To use Corese instead of FedX, just change askomics.federation_engine and askomics.federation_url in the config file.
Possible replacements for later :
- Remove @trace once Corese will be fixed about results parsing errors (note that in the current version some results can be excluded so keep an eye on Corese logs, use FedX in this case)
- Reintegrate prefixes in queries for Corese once its endpoint will be able to support it (low priority, just for debugging readability)

